### PR TITLE
Fixing Mono on some Linux installations

### DIFF
--- a/program.py
+++ b/program.py
@@ -37,7 +37,7 @@ class Program:
         'C++': ['%(exec)s'],
         'Java': ['java', '-Xmx1024m', '-Xss8m', '-cp', '%(execdir)s', '%(execbase)s'],
         'Python': ['python2', '%(mainfile)s'],
-        'C#': ['%(exec)s.exe'],
+        'C#': ['mono', '%(exec)s.exe'],
         'Go': ['%(exec)s'],
         'Haskell': ['%(exec)s'],
         'dir': ['%(path)s/run'],


### PR DESCRIPTION
Some Linux installations don't have properly registered .exe files to be run with mono. It needs some magic commands to be executed, see https://www.kernel.org/doc/Documentation/mono.txt

Another solution is to just run C# programs using mono executable, similar to the way java is run. This is the less painful way, so it will make problemtools more user-friendly.
