### PR TITLE
Minor code improvements.

### DIFF
--- a/default_validator/default_validator.cc
+++ b/default_validator/default_validator.cc
@@ -57,11 +57,10 @@ void openfile(Stream &stream, const char *file, const char *whoami) {
 }
 
 FILE *openfeedback(const char *feedbackdir, const char *feedback, const char *whoami) {
-	char path[10000];
-	sprintf(path, "%s/%s", feedbackdir, feedback);
-	FILE *res = fopen(path, "w");
+	std::string path = std::string(feedbackdir) + "/" + std::string(feedback);
+	FILE *res = fopen(path.c_str(), "w");
 	if (!res) {
-		judge_error("%s: failed to open %s for writing", whoami, path);
+		judge_error("%s: failed to open %s for writing", whoami, path.c_str());
 	}
 	return res;
 }
@@ -115,7 +114,7 @@ int main(int argc, char **argv) {
 	while (true) {
 		// Space!  Can't live with it, can't live without it...
 		while (isspace(judgeans.peek())) {
-			char c = judgeans.get();
+			char c = (char)judgeans.get();
 			if (space_change_sensitive) {
 				char d = std::cin.get();
 				if (c != d) {
@@ -128,7 +127,7 @@ int main(int argc, char **argv) {
 			++judgeans_pos;
 		}
 		while (isspace(std::cin.peek())) {
-			char d = std::cin.get();
+			char d = (char)std::cin.get();
 			if (space_change_sensitive) {
 				wrong_answer("Space change error: judge out of space, got %d from team", d);
 			}


### PR DESCRIPTION
Use std::string instead of fixed length char array.
Suppress warning by explicit downcast int -> char
(we've already checked for EOF, so this is safe to do)