### PR TITLE
Fix cosmetic issue with downcasting int to char.

### DIFF
--- a/default_validator/default_validator.cc
+++ b/default_validator/default_validator.cc
@@ -116,7 +116,7 @@ int main(int argc, char **argv) {
 		while (isspace(judgeans.peek())) {
 			char c = (char)judgeans.get();
 			if (space_change_sensitive) {
-				char d = std::cin.get();
+				int d = std::cin.get();
 				if (c != d) {
 					wrong_answer("Space change error: got %d expected %d", d, c);
 				}


### PR DESCRIPTION
Note that d can be set to EOF (normally represented by int(-1)),
so a cast to char _should_ not cause issues as char(255) is
not a space character.