### PR TITLE
Changed .gitmodules to use HTTPS instead of SSH to fetch checktestdata.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "checktestdata"]
 	path = support/checktestdata
-	url = git@github.com:Kattis/checktestdata.git
+	url = https://github.com/Kattis/checktestdata.git


### PR DESCRIPTION
As discussed in an email thread, the checktestdata submodule should be fetched using HTTPS instead of SSH, since:
- When running git clone with sudo (as is done when one tries to deploy Kattis), the user's ssh keys are not available.
- There is no point in requiring authorization to clone a public repo.