### PR TITLE
Add an option "noautoincludesamples"

### DIFF
--- a/templates/latex/problemset.cls
+++ b/templates/latex/problemset.cls
@@ -19,6 +19,9 @@
 
 \newif\if@clearevenpages\@clearevenpagestrue
 
+\newif\if@autoincludesamples\@autoincludesamplestrue
+\DeclareOption{noautoincludesamples}{\@autoincludesamplesfalse}
+
 \DeclareOption{plainproblems}{
   \@footerfalse
   \@problemnumbersfalse
@@ -157,13 +160,15 @@
   \startproblem{#1}
   \import{#1/problem_statement/}{problem\@problemlanguage.tex}
 
-  %% Automatically include samples 1..20
+  %% Automatically include samples 1..9, if enabled
   \ifplastex\else
+  \if@autoincludesamples
   \foreach \SampleNum in {1,...,9} {
     \IfFileExists{\@problemid/data/sample/\SampleNum.in}{
       \displaysample{\@problemid/data/sample/\SampleNum}
     }
   }
+  \fi
   \fi
 }
 

--- a/templates/latex/template.tex
+++ b/templates/latex/template.tex
@@ -1,4 +1,4 @@
-\documentclass[plainproblems]{problemset}
+\documentclass[plainproblems,noautoincludesamples]{problemset}
 
 \problemlanguage{%(language)s}
 


### PR DESCRIPTION
Add an option "noautoincludesamples" to disable automatic inclusion of sample data named 1.in ... 9.in (and *.ans).

This addresses https://github.com/Kattis/problemtools/issues/14