### PR TITLE
Return judge error if there is no output validator

### DIFF
--- a/src/verifyproblem.py
+++ b/src/verifyproblem.py
@@ -879,6 +879,7 @@ class OutputValidators(ProblemAspect):
         return res
 
     def validate(self, testcase, submission_output, errorhandler):
+        res = SubmissionResult('JE')
         for val in self._actual_validators():
             if val is not None and val.compile():
                 feedbackdir = tempfile.mkdtemp(prefix='feedback', dir=self._problem.tmpdir)


### PR DESCRIPTION
Return judge error if there is no output validator, as in `validate_interactive`
