### PR TITLE
Set stack size to unlimited when running submissions.

### DIFF
--- a/src/program.py
+++ b/src/program.py
@@ -64,6 +64,7 @@ class Runnable:
         if pid == 0:  # child
             try:
                 resource.setrlimit(resource.RLIMIT_CPU, (timelim, timelim + 1))
+                resource.setrlimit(resource.RLIMIT_STACK, (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
                 self._setfd(0, infile, os.O_RDONLY)
                 self._setfd(1, outfile, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
                 self._setfd(2, errfile, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)


### PR DESCRIPTION
This increases stack size to unlimited as it's done later by Kattis (and DOMjudge).