### PR TITLE
fix footer of covers containing page breaks

### DIFF
--- a/templates/latex/problemset.cls
+++ b/templates/latex/problemset.cls
@@ -312,8 +312,10 @@
     \fancyfoot[L]{
       \emph{
         \@contestshortname{}
-        \if@problemnumbers Problem \problemnumber:{} \fi
-        \@problemname
+        \ifdefined\@problemname
+          \if@problemnumbers Problem \problemnumber:{} \fi
+          \@problemname
+        \fi
         \ifx\@licenseblurb\@empty\relax\else
         \\\@licenseblurb
         \fi


### PR DESCRIPTION
We just created a problem set with a cover page that was longer than usual. It doesn't compile anymore if a page break occurs before the first problem since the footer of the cover's second page tries to use `\@problemname` which is not defined there.

It may be useful for others to merge this change since the second page is empty by default, but using it for additional hints results in an error.