### PR TITLE
add trailing separator to feedback argument

### DIFF
--- a/src/verifyproblem.py
+++ b/src/verifyproblem.py
@@ -845,7 +845,7 @@ class OutputValidators(ProblemAspect):
         for val in self._actual_validators():
             if val is not None and val.compile():
                 feedbackdir = tempfile.mkdtemp(prefix='feedback', dir=self._problem.tmpdir)
-                validator_args[2] = feedbackdir
+                validator_args[2] = feedbackdir + os.sep
                 f = tempfile.NamedTemporaryFile(delete=False)
                 interactive_out = f.name
                 f.close()


### PR DESCRIPTION
The feedbackdir argument should end with a trailing directory separator according to the specification.