### PR TITLE
Changing from dmcs to mcs to compile C#

### DIFF
--- a/problemtools/languages.yaml
+++ b/problemtools/languages.yaml
@@ -110,7 +110,7 @@ csharp:
     name: 'C#'
     priority: 700
     files: '*.cs'
-    compile: '/usr/bin/dmcs -out:{binary}.exe -optimize+ -r:System.Numerics {files}'
+    compile: '/usr/bin/mcs -out:{binary}.exe -optimize+ -r:System.Numerics {files}'
     run: '/usr/bin/mono {binary}.exe'
 
 go:


### PR DESCRIPTION
Second try!

`dmcs` is a wapper script, which forces the use of mono 4.0. Using `dmcs` creates a semi-broken installation, as mono 4.5 is shipped with ubuntu 16.04. Therefore we change to use `mcs` instead.

This matches the Kattis/kattis#1974 pull request for kattis backend.
