### PR TITLE
Support floats in .timelimit

### DIFF
--- a/problemtools/templates/latex/problemset.cls
+++ b/problemtools/templates/latex/problemset.cls
@@ -186,7 +186,7 @@
 }
 
 \newcommand{\ps@formattime}[1]{
-  #1\ifnum#1=1 second \else seconds \fi
+  #1\ifdim#1in=1in second \else seconds \fi
 }
 
 \newcommand{\problemheader}[2]{


### PR DESCRIPTION
Not sure if it's supported well by other parts of the toolchain, but we had a .timelimit (for the sake of CMS) of 1.5 in [one problem of KATT last year](https://github.com/oskmeister/po2016/blob/master/katt/Contest1/cities/), and problem2pdf choked on it.
