### PR TITLE
Fix python2 calls and shebangs

### DIFF
--- a/admin/make_release.sh
+++ b/admin/make_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/admin/update_version.py.sh
+++ b/admin/update_version.py.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/problem2html.sh
+++ b/bin/problem2html.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Wrapper script for running problemtools directly from within the
 # problemtools repo without installing it on the system.  When
@@ -6,4 +6,4 @@
 # not be used.
 
 export PYTHONPATH=$(readlink -f $(dirname $0)/..):$PYTHONPATH
-exec python -m problemtools.problem2html $@
+exec python2 -m problemtools.problem2html $@

--- a/bin/problem2pdf.sh
+++ b/bin/problem2pdf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Wrapper script for running problemtools directly from within the
 # problemtools repo without installing it on the system.  When
@@ -6,4 +6,4 @@
 # not be used.
 
 export PYTHONPATH=$(readlink -f $(dirname $0)/..):$PYTHONPATH
-exec python -m problemtools.problem2pdf $@
+exec python2 -m problemtools.problem2pdf $@

--- a/bin/verifyproblem.sh
+++ b/bin/verifyproblem.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Wrapper script for running problemtools directly from within the
 # problemtools repo without installing it on the system.  When
@@ -6,4 +6,4 @@
 # not be used.
 
 export PYTHONPATH=$(readlink -f $(dirname $0)/..):$PYTHONPATH
-exec python -m problemtools.verifyproblem $@
+exec python2 -m problemtools.verifyproblem $@

--- a/examples/hello/input_format_validators/validate.py
+++ b/examples/hello/input_format_validators/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 from sys import stdin
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 from setuptools import setup, find_packages
 from setuptools.command.bdist_egg import bdist_egg as _bdist_egg

--- a/support/default_grader/default_grader
+++ b/support/default_grader/default_grader
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import sys
 import argparse

--- a/support/viva/viva.sh
+++ b/support/viva/viva.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dir=`dirname $0`
 exec java -jar $dir/viva.jar $*


### PR DESCRIPTION
Explicitely call `python2` instead of 'python' since on some systems (e.g.
arch linux) python3 is the default version of python. Also do this in
shebangs.

Furthermore in shebangs, use the wrapper `/usr/bin/env` instead
of hard-coding the interpreter path. This makes scripts more portable,
because on some systems (mostly BSDs), bash is not in `/bin/` but
somewhere else in PATH.

See also some stackoverflow references for [Python shebangs](http://stackoverflow.com/a/19305076/4400896) and [Bash shebangs](http://stackoverflow.com/a/10383546/4400896). 