### PR TITLE
Add support for new grading settings.

### DIFF
--- a/support/default_grader/default_grader
+++ b/support/default_grader/default_grader
@@ -1,27 +1,49 @@
 #!/usr/bin/env python2
 
 import sys
-import argparse
 
-def avg(L): return 1.0*sum(L)/len(L)
 
-aggregators = {
+def no_errors(verdicts):
+    sorting_order = ['JE', 'IF', 'RTE', 'MLE', 'TLE', 'OLE', 'WA', 'PE', 'AC']
+    verdicts += ['AC']
+    index = min(sorting_order.index(verdict) for verdict in verdicts)
+    return sorting_order[index]
+
+
+def always_accept(verdicts):
+    return 'AC'
+
+verdict_aggregators = {
+    'no_errors': no_errors,
+    'always_accept': always_accept
+}
+
+
+def avg(scores):
+    return 1.0*sum(scores) / len(scores)
+
+
+score_aggregators = {
     'sum': sum,
     'avg': avg,
     'max': max,
     'min': min
-    }
+}
 
-parser = argparse.ArgumentParser(description='''Default grader.''')
-parser.add_argument('aggregation', help='aggregation type', default='sum', nargs = '?', action='store', choices = aggregators.keys())
-args = parser.parse_args()
+aggregate_scores = score_aggregators['sum']
+aggregate_verdicts = verdict_aggregators['no_errors']
 
-agg = aggregators[args.aggregation]
+for flag in sys.argv:
+    if flag in score_aggregators:
+        aggregate_scores = score_aggregators[flag]
+    if flag in verdict_aggregators:
+        aggregate_verdicts = verdict_aggregators[flag]
 
 try:
     data = sys.stdin.read().split()
+    verdicts = data[0::2]
     scores = map(float, data[1::2])
-    print 'AC %f' % agg(scores)
+    print '%s %f' % (aggregate_verdicts(verdicts), aggregate_scores(scores))
 except:
     print 'JE 0'
 


### PR DESCRIPTION
Some grading settings were moved from problem.yaml to testdata.yaml.
These settings should be read from there instead of problem.yaml.
Grading has also been reworked to accomodate for the fact that every
solution should now use the default grader (regardless of scoring), and
an on_reject setting per test case isntead.

@austrin I've done some prelim tests on old NCPC problems and our old PO problems, which both behave correctly. I also tested a new scoring problem using per-testgroup settings and on_reject, which worked fine.