### PR TITLE
Disable pybuild proxy for github.com

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,6 +9,7 @@ export PYBUILD_DISABLE=clean
 
 export PYBUILD_AFTER_CLEAN=make -C support distclean
 export PYBUILD_TEST_PYTEST=1
+export no_proxy=github.com
 
 %:
 	dh $@ --with python2 --buildsystem=pybuild


### PR DESCRIPTION
By default, pybuild proxies all http[s] requests to 127.0.0.1:9 to
prevent downloading dependencies from PyPi
(https://wiki.debian.org/Python/Pybuild). This has the consequence of
making the clone of checktestdata fail unless it has been cloned
before (e.g. by running make support previously). Adding a rule to
exclude github.com from this proxy makes building work again.