### PR TITLE
Use validator output if it exits first, for interactive problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.pyc
 *~
+/.cache/
+/problemtools.egg-info/
+/support/default_validator/default_validator
+/support/interactive/interactive

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -129,7 +129,7 @@ class TestCase(ProblemAspect):
         if anssize > outputlim:
             self.error('Answer file (%.1f Mb) is larger than output limit (%d Mb), you need to increase output limit' % (anssize, outputlim))
         elif 2 * anssize > outputlim:
-            self.warning('Answer file (%.1f Mb) is within %.0f%% of output limit (%d Mb), you might want to increase output limit' % (anssize, 100.0*anssize/outputlim, outputlim))
+            self.warning('Answer file (%.1f Mb) is within 50%% of output limit (%d Mb), you might want to increase output limit' % (anssize, outputlim))
         if not self._problem.is_interactive:
             val_res = self._problem.output_validators.validate(self, self.ansfile)
             if val_res.verdict != 'AC':

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -167,7 +167,7 @@ class TestCase(ProblemAspect):
             res2.runtime = runtime
         if sys.stdout.isatty():
             sys.stdout.write('%s' % '\b' * (len(msg)))
-        if res2.runtime <= timelim_low:
+        if res2.runtime <= timelim_low or res2.runtime > timelim_high:
             res1 = res2
         else:
             res1 = SubmissionResult('TLE', score=self.testcasegroup.config['reject_score'])
@@ -990,7 +990,7 @@ class OutputValidators(ProblemAspect):
 
 
     def validate_interactive(self, testcase, submission, timelim, errorhandler):
-        interactive_output_re = r'\d+ \d+\.\d+ \d+ \d+\.\d+'
+        interactive_output_re = r'\d+ \d+\.\d+ \d+ \d+\.\d+ (validator|submission)'
         res = SubmissionResult('JE')
         interactive = run.get_tool('interactive')
         if interactive is None:
@@ -1020,12 +1020,13 @@ class OutputValidators(ProblemAspect):
                     if not re.match(interactive_output_re, interactive_output):
                         errorhandler.error('Output from interactive does not follow expected format, got output "%s"' % interactive_output)
                     else:
-                        val_status, _, sub_status, sub_runtime = interactive_output.split()
+                        val_status, _, sub_status, sub_runtime, first = interactive_output.split()
                         sub_status = int(sub_status)
                         sub_runtime = float(sub_runtime)
                         val_status = int(val_status)
-
-                        if is_TLE(sub_status, True):
+                        if first == 'validator' and os.WIFEXITED(val_status) and os.WEXITSTATUS(val_status) == 43:
+                            res = self._parse_validator_results(val, val_status, feedbackdir, testcase)
+                        elif is_TLE(sub_status, True):
                             res = SubmissionResult('TLE', score=testcase.testcasegroup.config['reject_score'])
                         elif is_RTE(sub_status):
                             res = SubmissionResult('RTE', score=testcase.testcasegroup.config['reject_score'])

--- a/support/interactive/interactive.cc
+++ b/support/interactive/interactive.cc
@@ -23,48 +23,48 @@ static rusage val_ru;
 double runtime(rusage *ru) {
 	if(ru == NULL) return 0;
 
-    struct timeval tv;
-    tv.tv_sec = ru->ru_utime.tv_sec + ru->ru_stime.tv_sec;
-    tv.tv_usec = ru->ru_utime.tv_usec + ru->ru_stime.tv_usec;
-    return tv.tv_sec + tv.tv_usec / 1000000.0;
+	struct timeval tv;
+	tv.tv_sec = ru->ru_utime.tv_sec + ru->ru_stime.tv_sec;
+	tv.tv_usec = ru->ru_utime.tv_usec + ru->ru_stime.tv_usec;
+	return tv.tv_sec + tv.tv_usec / 1000000.0;
 }
 
 void report(int val_status, double val_time, int user_status, double user_time) {
 	FILE * fp = fdopen(report_fd, "w");
-    fprintf(fp, "%d %.6lf %d %.6lf", val_status, val_time, user_status, user_time);
+	fprintf(fp, "%d %.6lf %d %.6lf", val_status, val_time, user_status, user_time);
 	fclose(fp);
 }
 
 void walltime_handler(int a) {
-    int u_stat = user_status, v_stat = val_status;
-    double u_time = 0;
+	int u_stat = user_status, v_stat = val_status;
+	double u_time = 0;
 
-    // Check if validator has already quit while we were waiting for submission
-    if (val_pid != -1 && wait4(val_pid, &v_stat, WNOHANG, &val_ru) != val_pid)  {
-        kill(val_pid, SIGTERM);
-    } 
+	// Check if validator has already quit while we were waiting for submission
+	if (val_pid != -1 && wait4(val_pid, &v_stat, WNOHANG, &val_ru) != val_pid)  {
+		kill(val_pid, SIGTERM);
+	} 
 
-    // Check submission resource usage and then kill it
-    if (user_pid != -1 && wait4(user_pid, &u_stat, WNOHANG, &user_ru) != user_pid)
-        kill(user_pid, SIGKILL);
-    u_time = runtime(&user_ru);
+	// Check submission resource usage and then kill it
+	if (user_pid != -1 && wait4(user_pid, &u_stat, WNOHANG, &user_ru) != user_pid)
+		kill(user_pid, SIGKILL);
+	u_time = runtime(&user_ru);
 
-    if (u_stat == -1) {
-        // If validator already quit with WA but submission timed out
-        // on wall-time, don't tag submission as TLE but let validator
-        // decide.  (If validator quit with AC but submission kept
-        // running, tag submission as TLE.)
-        if (v_stat == (43 << 8)) u_stat = 0;
-        else {
-            u_stat = SIGUSR1;
-            u_time = walltimelimit;
-        }
-    } 
+	if (u_stat == -1) {
+		// If validator already quit with WA but submission timed out
+		// on wall-time, don't tag submission as TLE but let validator
+		// decide.  (If validator quit with AC but submission kept
+		// running, tag submission as TLE.)
+		if (v_stat == (43 << 8)) u_stat = 0;
+		else {
+			u_stat = SIGUSR1;
+			u_time = walltimelimit;
+		}
+	} 
 
-    // If validator didn't yet give us something, assume WA
-    if (v_stat == -1) v_stat = 43 << 8;
-    
-    report(v_stat, runtime(&val_ru), u_stat, u_time);
+	// If validator didn't yet give us something, assume WA
+	if (v_stat == -1) v_stat = 43 << 8;
+
+	report(v_stat, runtime(&val_ru), u_stat, u_time);
 	exit(0);
 }
 
@@ -157,8 +157,8 @@ int execute(char **args, int fdin, int fdout) {
 		}
 
 		if(execvp(args[0], args) == -1) {
-		   perror("execvp failed");
-		   exit(EXIT_FAILURE);
+			perror("execvp failed");
+			exit(EXIT_FAILURE);
 		}
 	} else if(pid < 0) {
 		perror("fork failed");
@@ -210,16 +210,16 @@ int main(int argc, char **argv) {
 		exit(EXIT_FAILURE);
 	}
 
-    char **val_argv = new char*[argc], **user_argv = new char*[argc];
-    int val_argc = 0, user_argc = 0;
+	char **val_argv = new char*[argc], **user_argv = new char*[argc];
+	int val_argc = 0, user_argc = 0;
 	for(int i = 3; i < argc && strcmp(argv[i], ";") != 0; ++i)
-        val_argv[val_argc++] = argv[i];
-    val_argv[val_argc] = NULL;
+		val_argv[val_argc++] = argv[i];
+	val_argv[val_argc] = NULL;
 
 	for(int i = 3 + val_argc + 1; i < argc; ++i) {
-        user_argv[user_argc++] = argv[i];
+		user_argv[user_argc++] = argv[i];
 	}
-    user_argv[user_argc] = NULL;
+	user_argv[user_argc] = NULL;
 
 	if(val_argc == 0 || user_argc == 0) {
 		fprintf(stderr, "Empty validator or user argument list\n");
@@ -236,9 +236,9 @@ int main(int argc, char **argv) {
 	val_pid = execute(val_argv, fromuser[0], fromval[1]);
 	user_pid = execute(user_argv, fromval[0], fromuser[1]);
 	if(walltimelimit) {
-        signal(SIGALRM, walltime_handler);
+		signal(SIGALRM, walltime_handler);
 		alarm(walltimelimit);
-    }
+	}
 	close(fromval[0]);
 	close(fromval[1]);
 	close(fromuser[0]);
@@ -249,19 +249,19 @@ int main(int argc, char **argv) {
 		perror("wait failed");
 		exit(1);
 	}
-    user_pid = -1;
+	user_pid = -1;
 
-    // In case of broken pipes, let validator decide
-    if(!WIFEXITED(user_status) && WTERMSIG(user_status) == SIGPIPE) {
-        user_status = 0;
-    }
+	// In case of broken pipes, let validator decide
+	if(!WIFEXITED(user_status) && WTERMSIG(user_status) == SIGPIPE) {
+		user_status = 0;
+	}
 
 	if(wait4(val_pid, &val_status, 0, &val_ru) == -1) {
 		perror("wait failed");
 		exit(1);
 	}
-    val_pid = -1;
+	val_pid = -1;
 
-    report(val_status, runtime(&val_ru), user_status, runtime(&user_ru));
+	report(val_status, runtime(&val_ru), user_status, runtime(&user_ru));
 	return 0;
 }


### PR DESCRIPTION
As per the commit message:

>Before this change, if a validator detected, say, an invalid input
format and exited, it would close its output pipe, and the submission
would proceed to read EOF and possibly crash/TLE. The output of the
submission would then be displayed to the user.
>
>This isn't great -- it either results in confusing judgements, or
necessitates adding convoluted clean exit protocols to the problem to
deal with these cases. In the latter case, the contestant needs to add
probably-unnecessary hard-to-test code, and the description of the
protocol can bog down the problem statement (see e.g. "Go, Gopher" from
Google Code Jam 2018: https://goo.gl/ccT6t3).
>
>This commit takes the stand that if the validator exits first with a WA
status, that should take precedence. Note that this may result in WA
statuses where the time limit is exceeded.

With a few other cleanups thrown in.

Changes the output format of `interactive.cc`, I don't know if that matters for other consumers than kattis.