### PR TITLE
Add a "partially accepted" directory

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1261,12 +1261,24 @@ class Submissions(ProblemAspect):
             self.warning('%s got %s' % (desc, result1))
         elif result1.verdict == expected_verdict:
             self.msg('   %s OK: %s' % (desc, result1))
+            if (expected_verdict == 'AC' and not partial
+                    and not self.fully_accepted(result1)
+                    and self.full_score_finite()):
+                # For some heuristic problems, this is expected. Thus, only warn.
+                self.warning('%s did not attain full score (consider moving it to partially_accepted)' % desc)
         elif result2.verdict == expected_verdict and not (partial and self.fully_accepted(result2)):
             self.msg('   %s OK with extra time: %s' % (desc, result2))
         else:
             self.error('%s got %s' % (desc, result1), result2.additional_info)
 
         return result1
+
+    def full_score_finite(self):
+        min_score, max_score = self._problem.testdata.get_score_range()
+        if self._problem.config.get('grading')['objective'] == 'min':
+            return min_score != -float('inf')
+        else:
+            return max_score != float('inf')
 
     def fully_accepted(self, result):
         min_score, max_score = self._problem.testdata.get_score_range()


### PR DESCRIPTION
It works like "accepted", except that:

- it is an error if a submission in `partially_accepted` gets full score
- it is a warning if a submission in `accepted` does not get full score
- submissions in `partially_accepted` do not affect the time limit (so this gives us a way to test TLE solutions for subtasks).

As a bonus, this allows us to give a warning whenever a submission in `accepted` doesn't get AC on the sample group. This is important since if the sample group is configured to give 0 points -- as it usually is for scoring problems -- verifyproblem won't otherwise give any hints about wrongly set sample answers. (We were very close to making this mistake for the Swedish Coding Cup.)

We may still want to add "expected score" annotations to submissions in the future; this does not preclude that.