### PR TITLE
Add subgroups visibility field, and require that visible subgroups have numerical names

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -198,8 +198,9 @@ class TestCaseGroup(ProblemAspect):
                        'on_reject': 'break',
                        'accept_score': 1.0,
                        'reject_score': 0.0,
-                       'range': '-inf +inf'
-   }
+                       'range': '-inf +inf',
+                       'subgroups': 'hidden'
+    }
 
     _SCORING_ONLY_KEYS = ['accept_score', 'reject_score', 'range']
 
@@ -306,8 +307,11 @@ class TestCaseGroup(ProblemAspect):
                 if self.config.get(key) is not None:
                     self.error("Key '%s' is only applicable for scoring problems, this is a pass-fail problem" % key)
 
-        if not self.config['on_reject'] in ['break', 'continue']:
+        if self.config['on_reject'] not in ['break', 'continue']:
             self.error("Invalid value '%s' for on_reject policy" % self.config['on_reject'])
+
+        if self.config['subgroups'] not in ['visible', 'hidden']:
+            self.error("Invalid value '%s' for subgroups visibility" % self.config['subgroups'])
 
         if self._problem.config.get('type') == 'scoring':
             # Check grading

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -203,6 +203,7 @@ class TestCaseGroup(ProblemAspect):
     }
 
     _SCORING_ONLY_KEYS = ['accept_score', 'reject_score', 'range']
+    _PUBLIC_SUBGROUP_REGEXP = r'^[0-9]+(\.[0-9]+)*[a-zA-Z]?$'
 
     def __init__(self, problem, datadir, parent=None):
         self._parent = parent
@@ -361,6 +362,13 @@ class TestCaseGroup(ProblemAspect):
             for _, files in hashes.iteritems():
                 if len(files) > 1:
                     self.warning("Identical input files: '%s'" % str(files))
+
+        if self._parent is not None and self.config['subgroups'] == 'visible':
+            for item in self._items:
+                if isinstance(item, TestCaseGroup):
+                    name = os.path.basename(item._datadir)
+                    if not re.match(TestCaseGroup._PUBLIC_SUBGROUP_REGEXP, name):
+                        self.error("Visible testgroup '%s' must have numeric name (matching '%s')" % (name, TestCaseGroup._PUBLIC_SUBGROUP_REGEXP))
 
         for f in infiles:
             if not f[:-3] + '.ans' in ansfiles:


### PR DESCRIPTION
For discussion. As I see it, we need either a visibility field, or to say that subgroups should always be displayed in the judge UI (but we have a bit of legacy content for which that doesn't make sense). Certainly I think the way Kattis does it right now, where subgroup visibilities are configured per-site within the judge, is broken. Subgroup visibility is a property of the problem: either the problem statement mentions what subgroups exist, in which case the judge should always show group results, or it doesn't, and it shouldn't.

(Also, we have had problems with the current setup -- one contest was accidentally misconfigured and we heard only after the contest that contestants had gotten no feedback about test groups... Putting the config flag in testdata.yaml eliminates that problem.)

This PR adds a subgroup visibility field, and defaults it to off. This gives us the unique chance to make a (non-breaking!) change that visible groups have to have (mostly-)numerical names, which a judge can format as `Group N` in any language. The current situation is that subgroup presentations are left unspecified -- Kattis shows raw directory names which is not good from a localization or UI control perspective.

The topmost `subgroups` flag is intended to be ignored (other than for inheritance into subconfigs); the judge should itself decide whether to show sample and secret group outcomes.

Possible points of discussion (though I'm quite happy with this PR as is):
* what should the default visibility be?
* what should the flag be called?
* should the flag affect whether all the children are visible, or whether the current group is? (IMO the first is simpler, and having only a subset of subgroups show up is confusing.) Or should it even be in problem.yaml and affect all groups? (Simpler yet, but loses too much flexibility I suspect.)
* do we want to impose this requirement on group names?
* what precise pattern do we accept? I felt that `5.2.4a` was reasonable subgroup name, so wrote a regex that accepts that... but we could just as well limit ourselves to purely numerical names, or to some other pattern.
* should group names be a function of directory names, or of some testdata.yaml flag, or auto-generated (group 1, group 2, ...)? (IMO putting them into testdata.yaml isn't a win, and auto-generating is too risky... but it's worth noting the option)