### PR TITLE
Implement bad inputs for input/output format validators

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1013,12 +1013,8 @@ class OutputValidators(ProblemAspect):
                     self.warning('Output validator check with wrong answers for interactive problems is currently not supported (skipping)')
                     return
 
-                if self._problem.config.get('validation') == 'default':
-                    self.warning('Output validator check with wrong answers and default validator is unnecessary (skipping)')
-                    return
-
             for wafile in wrong_answers:
-                for val in self._validators:
+                for val in self._actual_validators():
                     feedbackdir = tempfile.mkdtemp(prefix='feedback', dir=self._problem.tmpdir)
                     status, runtime = val.run(wafile,
                                               args=[testcase.infile, testcase.ansfile, feedbackdir] + flags,

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -836,7 +836,7 @@ class InputFormatValidators(ProblemAspect):
                     self.error('Input format validator %s crashed on input %s' % (val, invalid_infile))
 
                 # If an input validator declines the input file, everything is fine and we break.
-                if os.WEXITSTATUS(status) == 42:
+                if os.WEXITSTATUS(status) == 43:
                     break
             else:
                 # Will only be executed if loop wasn't ended by break.

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -359,19 +359,16 @@ class TestCaseGroup(ProblemAspect):
                 if len(files) > 1:
                     self.warning("Identical input files: '%s'" % str(files))
 
-        wafiles_with_input = []
-
         for f in infiles:
             if not f[:-3] + '.ans' in ansfiles:
                 self.error("No matching answer file for input '%s'" % f)
-            wafiles_with_input.extend(glob.glob(OutputValidators.WA_GLOB % (f[:-3] + '.ans')))
 
         for f in ansfiles:
             if not f[:-4] + '.in' in infiles:
                 self.error("No matching input file for answer '%s'" % f)
 
         for f in wafiles:
-            if f not in wafiles_with_input:
+            if f.split('.ans.wrong-')[0] + '.in' not in infiles:
                 self.error("No matching input file for wrong answer '%s'" % f)
 
         for subdata in self._items:


### PR DESCRIPTION
Now it's possible to specify invalid inputs and outputs which should be declined by input/output format validators. See #51 for details.

Usage:
 - Input Format Validator:  place .in files into a folder input_format_validators/bad_inputs, this input files should be declined by input validators
 - Output Format Validator: place {testcasename}.ans.wrong-{something} into data/{category}/ for wrong answers to inputfile {testcasename}.in. This wrong answers should be declined by the output validators. Interactive problems are currently not supported. A warning will occur if the inputfile doesn't exist (in case of misspelling)