### PR TITLE
Fix input format validator skip by non-compiling validators

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -731,7 +731,7 @@ class InputFormatValidators(ProblemAspect):
         if len(self._validators) == 0:
             self.error('No input format validators found')
 
-        for val in self._validators:
+        for val in self._validators[:]:
             try:
                 if not val.compile():
                     self.error('Compile error for %s' % val)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -920,10 +920,13 @@ class OutputValidators(ProblemAspect):
         if self._problem.config.get('validation') == 'default' and self._default_validator is None:
             self.error('Unable to locate default validator')
 
-        for val in self._validators:
-            if not val.compile():
-                self.error('Compile error for output validator %s' % val)
-
+        for val in self._validators[:]:
+            try:
+                if not val.compile():
+                    self.error('Compile error for output validator %s' % val)
+                    self._validators.remove(val)
+            except run.ProgramError as e:
+                self.error(e)
 
         # Only sanity check output validators if they all actually compiled
         if self._check_res:


### PR DESCRIPTION
If a validator doesn't compile, the next one won't be compiled because the iteration skips one step. Copying the list first fixes this problem.

Additionally, the output validator is modified to have the same behaviour