### PR TITLE
Remove -i flag from html tidy

### DIFF
--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -74,7 +74,7 @@ def convert(problem, options=None):
             os.remove('.paux')
 
         if options.tidy:
-            os.system('tidy -utf8 -i -q -m %s 2> /dev/null' % destfile)
+            os.system('tidy -utf8 -q -m %s 2> /dev/null' % destfile)
 
         if options.bodyonly:
             content = open(destfile).read()


### PR DESCRIPTION
Fixes #89 

Using this can introduce unwanted linebreaks and spaces inside `<pre>`
blocks. See the first example under
http://www.html-tidy.org/documentation/#featured-options-and-solutions