### PR TITLE
problem2html.py: Print warning if 'tidy' is not installed.

### DIFF
--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -75,7 +75,9 @@ def convert(problem, options=None):
             os.remove('.paux')
 
         if options.tidy:
-            os.system('tidy -utf8 -i -q -m %s 2> /dev/null' % destfile)
+            tidy_exitcode = os.system('tidy -utf8 -i -q -m %s 2> /dev/null' % destfile)
+            if not options.quiet and os.WEXITSTATUS(tidy_exitcode) == 127:
+                print "Warning: Command 'tidy' not found. Install tidy or run with --messy"
 
         if options.bodyonly:
             content = open(destfile).read()


### PR DESCRIPTION
If the program 'tidy' is missing, the error code is currently just
ignored. This way, you you end up with some messy html without a warning
or anything.

Now, problem2html prints a warning if tidy is not installed.

Signed-off-by: Stefan Kraus <stefan.kraus@fau.de>