### PR TITLE
Add dependencies on Fedora to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ and a LaTeX installation.  In Ubuntu, the precise dependencies are as follows:
 
     libboost-regex1.54.0, libc6 (>= 2.14), libgcc1 (>= 1:4.1.1), automake, libgmp-dev, libgmp10, libgmpxx4ldbl, libstdc++6 (>= 4.4.0), python (>= 2.7), python (<< 2.8), python:any (>= 2.7.1-0ubuntu2), python-yaml, python-plastex, texlive-latex-recommended, texlive-fonts-recommended, texlive-latex-extra, texlive-lang-cyrillic, tidy, ghostscript
 
+On Fedora, these dependencies can be installed with:
+
+    sudo dnf install boost-regex gcc gmp-devel gmp-c++ python2 python2-pyyaml texlive-latex texlive-collection-fontsrecommended texlive-fancyhdr texlive-subfigure texlive-wrapfig texlive-import texlive-ulem texlive-xifthen texlive-overpic texlive-pbox tidy ghostscript
+
+Followed by:
+
+    pip2 install --user plastex
+
 The problem tools have not been tested on other platforms.  If you do
 test on another platform, we'd be happy to hear what worked and what
 did not work, so that we can write proper instructions (and try to


### PR DESCRIPTION
I was able to get all three programs working on Fedora 28 with these sets of dependencies. They're not necessarily complete as I started by translating the Ubuntu dependencies (and as this is a development machine, I had several dependencies already installed). With the exception of all the texlive packages missing from the Ubuntu dependencies, everything seemed to work well. Also, Fedora doesn't package `plastex` so I recommended installing that via `pip install --user`.

As a heads up, I'm not sure the future plans of this project, but you're looking at about a two year window for Fedora [dropping full support for Python 2](https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3). Fedora 29 will hopefully be released next week, Fedora 30 will drop support for python2 packages, and 33 looking like it will drop python2 completely. (Roughly 6 month release cycle). Fedora 30 is of interest if you want to see `problemtools` packaged in Fedora, otherwise for anyone running `problemtools` on Fedora, the Fedora 33 release is of interest.

I haven't looked into how much work porting problemtools to python3 would be, just figured I'd mention it as a heads up. I'd assume other distributions have similar plans. :)

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`