### PR TITLE
Add Docker to Kattis problemtools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:18.04
 
-RUN export DEBIAN_FRONTEND=noninteractive && \
+RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update && \
-    apt-get install -y sudo git curl automake tidy libboost-all-dev libgmp-dev libgmp10 libgmpxx4ldbl python-plastex texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-lang-cyrillic python-yaml vim python-minimal openjdk-8-jdk g++ && \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    pip2 install --upgrade pip && \
+    apt-get install -y sudo git curl automake tidy libboost-all-dev libgmp-dev libgmp10 libgmpxx4ldbl python-plastex texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-lang-cyrillic python-yaml vim python-minimal openjdk-8-jdk g++; \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; \
+    python get-pip.py; \
+    pip2 install --upgrade pip; \
     pip install git+https://github.com/kattis/problemtools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Download ubuntu image with python and pip
+FROM nitincypher/docker-ubuntu-python-pip
+
+RUN apt-get update && \
+    apt-get install -y sudo && \
+    apt-get install -y git && \
+    apt-get install -y automake && \
+    apt-get install -y tidy && \
+    apt-get install -y libboost-all-dev && \
+    apt-get install -y libgmp-dev libgmp10 libgmpxx4ldbl && \
+    apt-get install -y python-plastex && \
+    apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-lang-cyrillic && \
+    apt-get install -y python-yaml && \
+    apt-get install -y vim && \
+    apt-get install -y openjdk-8-jdk && \
+    apt-get install -y g++ && \
+    pip2 install --upgrade pip && \
+    pip install git+https://github.com/kattis/problemtools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,9 @@
-# Download ubuntu image with python and pip
-FROM nitincypher/docker-ubuntu-python-pip
+FROM ubuntu:18.04
 
-RUN apt-get update && \
-    apt-get install -y sudo && \
-    apt-get install -y git && \
-    apt-get install -y automake && \
-    apt-get install -y tidy && \
-    apt-get install -y libboost-all-dev && \
-    apt-get install -y libgmp-dev libgmp10 libgmpxx4ldbl && \
-    apt-get install -y python-plastex && \
-    apt-get install -y texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-lang-cyrillic && \
-    apt-get install -y python-yaml && \
-    apt-get install -y vim && \
-    apt-get install -y openjdk-8-jdk && \
-    apt-get install -y g++ && \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update && \
+    apt-get install -y sudo git curl automake tidy libboost-all-dev libgmp-dev libgmp10 libgmpxx4ldbl python-plastex texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-lang-cyrillic python-yaml vim python-minimal openjdk-8-jdk g++ && \
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
+    python get-pip.py && \
     pip2 install --upgrade pip && \
     pip install git+https://github.com/kattis/problemtools

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:18.04
 
 RUN export DEBIAN_FRONTEND=noninteractive; \
     apt-get update && \
-    apt-get install -y sudo git curl automake tidy libboost-all-dev libgmp-dev libgmp10 libgmpxx4ldbl python-plastex texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-lang-cyrillic python-yaml vim python-minimal openjdk-8-jdk g++; \
-    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py; \
-    python get-pip.py; \
+    apt-get install -y sudo git python-pip automake tidy libboost-all-dev libgmp-dev libgmp10 libgmpxx4ldbl python-plastex texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra texlive-lang-cyrillic python-yaml vim python-minimal openjdk-8-jdk g++; \
     pip2 install --upgrade pip; \
     pip install git+https://github.com/kattis/problemtools

--- a/README.md
+++ b/README.md
@@ -98,6 +98,30 @@ This installs the three provided programs in your path and they should
 now be ready to use.
 
 
+### Method 4: Use Docker
+
+This method allows you to run the Kattis problemtools inside a docker container. This method is supported on **macOS**, **Windows 10** and several linux distros. The true advantage to this approach is that docker installs all the required dependencies for the Kattis problemtools and places the correct programs on your `$PATH`.
+
+To get started, install the [Docker CLI](https://docs.docker.com/install) and build the Kattis problemtools docker image using the Dockerfile in the top directory of this project. This will download the correct Ubuntu image and install all the Kattis problemtools.
+
+    problemtools$ docker build . kattis_problemtools_image
+
+Once the image has finished installing, you can check it exists on your system using `docker images`. To launch an interactive container and play around with *verifyproblem*, *problem2pdf*, and *problem2html* run:
+
+    docker run -it kattis_problemtools_image
+
+**WARNING:** By default, docker containers to _NOT_ persist storage between runs, so any files you create or modify will be lost when the container stops running. 
+
+There are several way of getting around this:
+
+1) Persist any changes you want to keep to a remote file system/source control (e.g Github)
+
+2) Another way to save any work you do in a docker container is to use a [docker volume](https://docs.docker.com/storage/volumes). A docker volume acts as a special directory which is persisted and shared between containers. Below we create a docker volume and mount the volume to our image as the directory `/kattis_work_dir`
+
+    docker volume create kattis-work-volume
+    docker run -it -v kattis-work-volume:/kattis_work_dir kattis_problemtools_image
+
+
 ## Requirements and compatibility
 
 To run the tools, you need Python 2 with the YAML and PlasTeX libraries,

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This method allows you to run the Kattis problemtools inside a docker container.
 
 To get started, install the [Docker CLI](https://docs.docker.com/install) and build the Kattis problemtools docker image using the Dockerfile in the top directory of this project. This will download the correct Ubuntu image and install all the Kattis problemtools.
 
-    problemtools$ docker build . kattis_problemtools_image
+    problemtools$ docker build -t kattis_problemtools_image .
 
 Once the image has finished installing, you can check it exists on your system using `docker images`. To launch an interactive container and play around with *verifyproblem*, *problem2pdf*, and *problem2html* run:
 
@@ -112,7 +112,7 @@ Once the image has finished installing, you can check it exists on your system u
 
 **WARNING:** By default, docker containers to _NOT_ persist storage between runs, so any files you create or modify will be lost when the container stops running. 
 
-There are several way of getting around this:
+There are several ways of getting around this:
 
 1) Persist any changes you want to keep to a remote file system/source control (e.g Github)
 


### PR DESCRIPTION
I have ran into the issue of wanting to create a Kattis problem in the past but not being able to install the Kattis problemtools. In particular, usually one of the following happens: 
1) I'm unable to access the proper OS
2) pip install is broken
3) Idk what dependencies i'm missing 
4) all of the above :sob:

To resolve this issue, I propose having an Ubuntu docker image with the Kattis probemtools and dependencies installed to avoid all this hassle. This way, problem creators can simply boot up an interactive container and get to work :tada: