### PR TITLE
Allow Input and Output latex environments

### DIFF
--- a/problemtools/templates/latex/problemset.cls
+++ b/problemtools/templates/latex/problemset.cls
@@ -92,6 +92,8 @@
                                    {-3ex}%
                                    {1ex}%
                                    {\normalfont\large\sf\bfseries}}
+\newenvironment{Input}{\section*{Input}}{}
+\newenvironment{Output}{\section*{Output}}{}
 
 \renewcommand\subsection{\@startsection{subsection}{2}{\z@}%
                                      {-3.55ex}%


### PR DESCRIPTION
This allows for wrapping the Input and Output sections in an environment. Instead of hardcoding the `\section*{Input}` in the latex source, you can now also write:
```
\begin{Input}
The input is ...
\end{Input}
```

We use this in our BAPC repository because it gives some more flexibility. Here, I just map the begin of the environment to create a new uncounted section, like the default behaviour.