### PR TITLE
fix bash run scripts

### DIFF
--- a/bin/problem2html.sh
+++ b/bin/problem2html.sh
@@ -5,5 +5,6 @@
 # installing problemtools on the system properly, this script should
 # not be used.
 
-export PYTHONPATH=$(readlink -f $(dirname $0)/..):$PYTHONPATH
-exec python2 -m problemtools.problem2html $@
+export PYTHONPATH
+PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
+exec python2 -m problemtools.problem2html "$@"

--- a/bin/problem2pdf.sh
+++ b/bin/problem2pdf.sh
@@ -5,5 +5,6 @@
 # installing problemtools on the system properly, this script should
 # not be used.
 
-export PYTHONPATH=$(readlink -f $(dirname $0)/..):$PYTHONPATH
-exec python2 -m problemtools.problem2pdf $@
+export PYTHONPATH
+PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
+exec python2 -m problemtools.problem2pdf "$@"

--- a/bin/verifyproblem.sh
+++ b/bin/verifyproblem.sh
@@ -5,5 +5,6 @@
 # installing problemtools on the system properly, this script should
 # not be used.
 
-export PYTHONPATH=$(readlink -f $(dirname $0)/..):$PYTHONPATH
-exec python2 -m problemtools.verifyproblem $@
+export PYTHONPATH
+PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
+exec python2 -m problemtools.verifyproblem "$@"


### PR DESCRIPTION
I noticed that using problemtools via bash scripts did not support checking more than one problem definition. So when running `verifyproblem dog/ report/` the result is `verifyproblem.py: error: unrecognized arguments: report/`

This issue is fixed by the arguments from passing the arguments to the program with quotes: `"$@"`

---

Second issue was that the invoked python code changed depending on where the user was located.

This could be explained by a strange order of expanding the bash script location. The path is now first canonicalized and then we go up two levels to get to the proper folder. Note that `realpath` should be used instead of `readlink -f` but I am not sure about cross-platform compatibility, so this is not changed.

Hope this helps :)