### PR TITLE
Update default grader with first_error, worst_error, ignore_sample, prefer_accepted

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -956,7 +956,7 @@ class Graders(ProblemAspect):
             graders = self._graders
 
         grader_input = ''.join(['%s %s\n' % (r.verdict, 0 if r.score is None else r.score) for r in sub_results])
-        grader_output_re = r'^((AC)|(WA)|(TLE)|(RTE))\s+[0-9.]+\s*$'
+        grader_output_re = r'^((AC)|(WA)|(TLE)|(RTE)|(JE))\s+[0-9.]+\s*$'
         verdict = 'AC'
         score = 0
 

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -385,6 +385,12 @@ class TestCaseGroup(ProblemAspect):
         if self.config['grading'] == 'default' and Graders._default_grader is None:
             self._problem.graders.error('%s has default grading but I could not find default grader' % self)
 
+        if self.config['grading'] == 'default' and 'ignore_sample' in self.config['grader_flags'].split():
+            if self._parent is not None:
+                self.error("'grader_flags: ignore_sample' is specified, but that flag is only allowed at top level")
+            elif self.config['on_reject'] == 'break':
+                self.error("'grader_flags: ignore_sample' is specified, but 'on_reject: break' may cause secret data not to be judged")
+
         for field in self.config.keys():
             if field not in TestCaseGroup._DEFAULT_CONFIG.keys():
                 self.warning("Unknown key '%s' in '%s'" % (field, os.path.join(self._datadir, 'testdata.yaml')))
@@ -394,7 +400,7 @@ class TestCaseGroup(ProblemAspect):
                 if self.config.get(key) is not None:
                     self.error("Key '%s' is only applicable for scoring problems, this is a pass-fail problem" % key)
 
-        if not self.config['on_reject'] in ['break', 'continue']:
+        if self.config['on_reject'] not in ['break', 'continue']:
             self.error("Invalid value '%s' for on_reject policy" % self.config['on_reject'])
 
         if self._problem.is_scoring:

--- a/support/default_grader/default_grader
+++ b/support/default_grader/default_grader
@@ -3,25 +3,31 @@
 import sys
 
 
-def no_errors(verdicts):
+def worst_error(verdicts):
     sorting_order = ['JE', 'IF', 'RTE', 'MLE', 'TLE', 'OLE', 'WA', 'PE', 'AC']
     verdicts += ['AC']
     index = min(sorting_order.index(verdict) for verdict in verdicts)
     return sorting_order[index]
 
+def first_error(verdicts):
+    for verdict in verdicts:
+        if verdict != 'AC':
+            return verdict
+    return 'AC'
 
 def always_accept(verdicts):
     return 'AC'
 
 verdict_aggregators = {
-    'no_errors': no_errors,
+    'worst_error': worst_error,
+    'no_errors': worst_error,
+    'first_error': first_error,
     'always_accept': always_accept
 }
 
 
 def avg(scores):
     return 1.0*sum(scores) / len(scores)
-
 
 score_aggregators = {
     'sum': sum,
@@ -30,21 +36,36 @@ score_aggregators = {
     'min': min
 }
 
+
 aggregate_scores = score_aggregators['sum']
-aggregate_verdicts = verdict_aggregators['no_errors']
+aggregate_verdicts = verdict_aggregators['worst_error']
+ignore_sample = False
+accept_if_any_accepted = False
 
 for flag in sys.argv:
     if flag in score_aggregators:
         aggregate_scores = score_aggregators[flag]
     if flag in verdict_aggregators:
         aggregate_verdicts = verdict_aggregators[flag]
+    if flag == 'ignore_sample':
+        ignore_sample = True
+    if flag == 'accept_if_any_accepted':
+        accept_if_any_accepted = True
 
 try:
     data = sys.stdin.read().split()
     verdicts = data[0::2]
-    scores = map(float, data[1::2])
-    print '%s %f' % (aggregate_verdicts(verdicts), aggregate_scores(scores))
+    scores = list(map(float, data[1::2]))
+    assert len(verdicts) == len(scores)
+    if ignore_sample:
+        assert 1 <= len(verdicts) <= 2
+        verdicts = verdicts[-1:]
+        scores = scores[-1:]
+    if accept_if_any_accepted and 'AC' in verdicts:
+        verdict = 'AC'
+    else:
+        verdict = aggregate_verdicts(verdicts)
+    score = aggregate_scores(scores)
+    print '%s %f' % (verdict, score)
 except:
     print 'JE 0'
-
-sys.exit(0)


### PR DESCRIPTION
Recently added to the spec after some discussion with @niemela. first_error is rarely useful, but can be good for avoiding timing leaks and for analytics in judges that don't do lower-priority judging of unnecessary testcases. worst_error is a better name for no_errors. ignore_sample is useful for scoring problems (unless secret/ has a grader that always outputs Accepted (0), as we're doing with PO; a Rejected status would help with that).