### PR TITLE
Correctly capitalize Mainclass, only change first letter

### DIFF
--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -72,7 +72,7 @@ class SourceCode(Program):
             self.mainfile = self.src[0]
 
         self.mainclass = os.path.splitext(os.path.basename(self.mainfile))[0]
-        self.Mainclass = self.mainclass.capitalize()
+        self.Mainclass = self.mainclass[0].upper() + self.mainclass[1:]
 
         self.binary = os.path.join(self.path, 'run')
 


### PR DESCRIPTION
Python's string `capitalize` function indeed capitalizes the first character of the string, but it also converts all other characters in the string to lowercase. For example, "e_CorrecT" would be `capitalize`d to "E_correct".

However, `kotlinc` only capitalizes the first letter of the class and leaves the other characters unchanged. For example, "e_CorrecT" will be compiled by Kotlin to "E_CorrecTKt". The definition of the `Mainclass` variable has been updated to fix this (the "Kt" suffix is handled in config/languages.yaml).