### PR TITLE
Use edition 2018 of rust for compilation

### DIFF
--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -222,7 +222,7 @@ rust:
     name: 'Rust'
     priority: 575
     files: '*.rs'
-    compile: '/usr/bin/rustc -o{binary} -O --crate-type bin {files}'
+    compile: '/usr/bin/rustc -o{binary} -O --crate-type bin --edition=2018 {files}'
     run: '{binary}'
 
 scala:


### PR DESCRIPTION
Rust defaults to the 2015 edition, unless you explicitly tell rustc to use the 2018 edition. 