### PR TITLE
Use -std=gnu++17

### DIFF
--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -105,7 +105,7 @@ cpp:
     name: 'C++'
     priority: 1000
     files: '*.cc *.C *.cpp *.cxx *.c++'
-    compile: '/usr/bin/g++ -g -O2 -std=gnu++14 -static -o {binary} {files}'
+    compile: '/usr/bin/g++ -g -O2 -std=gnu++17 -static -o {binary} {files}'
     run: '{binary}'
 
 csharp:


### PR DESCRIPTION
This would make problemtools consistent with Kattis.

I can only think of one reason *not* to do this: ICPC rules still list `-std=gnu++14` (https://icpc.baylor.edu/xwiki/wiki/public/view/worldfinals/programming-environment)