### PR TITLE
require plasTeX version 1.0 for python2 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(name='problemtools',
       include_package_data=True,
       install_requires=[
           'PyYAML',
-          'plasTeX',
+          'plasTeX==1.0',
       ],
       python_requires='<3',
 #      Temporarily disabled, see setup.cfg


### PR DESCRIPTION
I have had two reports of people recently installing problemtools using pip, and it fails to run because of the version of plasTeX that pip installs.

The latest plasTeX (https://github.com/plastex/plastex) recently updated from 1.0 to 2.0, and 2.0 is for python 3.

This PR fixes the issue by having problemtools tell pip to use version 1.0.

I've tested this in a clean docker instance:
```
$ docker pull python:2.7.17-stretch
$ docker run -it --rm python:2.7.17-stretch /bin/bash
# pip install -e git://github.com/ghamerly/problemtools.git@use-plastex1.0#egg=problemtools
# verifyproblem
```
which installs plasTeX 1.0, and verifyproblem can run.

If you replace the github URL above with `git://github.com/Kattis/problemtools.git#egg=problemtools`, it still installs, but with plasTeX 2.0, and running verifyproblem fails.

Of course, when #116 is fixed, then we can revert this (or require 2.0). Maybe it's time to do that anyway, as I'm tired of how broken plasTeX is, and maybe the new version is better?