### PR TITLE
Reenable Python3 in the setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,9 +81,9 @@ setup(name='problemtools',
       include_package_data=True,
       install_requires=[
           'PyYAML',
-          'plasTeX==1.0',
+          'plasTeX==1.0;python_version<"3"',
+          'plasTeX>=2.0;python_version>="3"'
       ],
-      python_requires='<3',
 #      Temporarily disabled, see setup.cfg
 #      For now tests can be run manually with pytest
 #      setup_requires=['pytest-runner'],


### PR DESCRIPTION
Tested in a clean Ubuntu 18.04 image that running `pip install` causes it to fetch PlasTeX 1.0, and running `pip3 install` causes it to fetch PlasTeX 2.0.

Closes #116.