### PR TITLE
Build debian for python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
-python: 2.7
+python:
+  - 2.7
+  - 3.7
 
 script: py.test

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: kattis-problemtools
 Section: devel
 Priority: optional
 Maintainer: Per Austrin <austrin@kattis.com>
-Build-Depends: debhelper (>= 8.0.0), g++ (>= 4.8), dh-python, python (>= 2.6.6-3~), python-setuptools, python-pytest, python-yaml, libboost-regex-dev, libgmp-dev, automake, autoconf
+Build-Depends: debhelper (>= 8.0.0), g++ (>= 4.8), dh-python, python (>= 2.6.6-3~), python3 (>=3.7), python-setuptools, python-pytest, python-yaml, libboost-regex-dev, libgmp-dev, automake, autoconf
 Standards-Version: 3.9.4
 Homepage: https://github.com/Kattis/problemtools
 
 Package: kattis-problemtools
 Architecture: any
-Depends: ${shlibs:Depends}, ${python:Depends}, ${misc:Depends}, python-yaml, python-plastex, python-pkg-resources, texlive-latex-recommended, texlive-fonts-recommended, texlive-latex-extra, texlive-generic-recommended, texlive-lang-cyrillic, tidy, ghostscript
+Depends: ${shlibs:Depends}, ${python:Depends}, ${python3:Depends}, ${misc:Depends}, python-yaml, python-plastex, python-pkg-resources, texlive-latex-recommended, texlive-fonts-recommended, texlive-latex-extra, texlive-generic-recommended, texlive-lang-cyrillic, tidy, ghostscript
 Recommends: gcc, g++
 Description: Kattis Problem Tools
  These are tools to manage and verify problem packages in the

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Per Austrin <austrin@kattis.com>
 Build-Depends: debhelper (>= 8.0.0), g++ (>= 4.8), dh-python, python (>= 2.6.6-3~), python3 (>=3.7), python-setuptools, python-pytest, python-yaml, libboost-regex-dev, libgmp-dev, automake, autoconf
 Standards-Version: 3.9.4
 Homepage: https://github.com/Kattis/problemtools
+X-Python3-Version: 3.7
 
 Package: kattis-problemtools
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -12,4 +12,4 @@ export PYBUILD_TEST_PYTEST=1
 export no_proxy=github.com
 
 %:
-	dh $@ --with python2 --buildsystem=pybuild
+	dh $@ --with python2,python3 --buildsystem=pybuild

--- a/problemtools/languages.py
+++ b/problemtools/languages.py
@@ -4,10 +4,8 @@ of programming languages.
 """
 import fnmatch
 import re
-import os
 import string
-import types
-import yaml.parser
+from six import string_types
 
 from . import config
 
@@ -77,12 +75,12 @@ class Language(object):
         for (key, value) in values.items():
             # Check type
             if key == 'priority':
-                if type(value) != int:
+                if not isinstance(value, int):
                     raise LanguageConfigError(
                         'Language %s: priority must be integer but is %s.'
                         % (self.lang_id, type(value)))
             else:
-                if type(value) != bytes:
+                if not isinstance(value, string_types):
                     raise LanguageConfigError(
                         'Language %s: %s must be string but is %s.'
                         % (self.lang_id, key, type(value)))
@@ -209,18 +207,18 @@ class Languages(object):
                 for a language already in the set, the configuration
                 for that language will be overridden and updated.
         """
-        if type(data) is not dict:
+        if not isinstance(data, dict):
             raise LanguageConfigError(
                 'Config file error: content must be a dictionary, but is %s.'
                 % (type(data)))
 
         for (lang_id, lang_spec) in data.items():
-            if type(lang_id) is not bytes:
+            if not isinstance(lang_id, string_types):
                 raise LanguageConfigError(
                     'Config file error: language IDs must be strings, but %s is %s.'
                     % (lang_id, type(lang_id)))
 
-            if type(lang_spec) is not dict:
+            if not isinstance(lang_spec, dict):
                 raise LanguageConfigError(
                     'Config file error: language spec must be a dictionary, but spec of language %s is %s.'
                     % (lang_id, type(lang_spec)))

--- a/problemtools/tests/test_languages.py
+++ b/problemtools/tests/test_languages.py
@@ -89,10 +89,9 @@ class Language_test(TestCase):
         vals['priority'] = 2.3
         with pytest.raises(languages.LanguageConfigError):
             languages.Language('id', vals)
-        vals['priority'] = 10**1000
+        vals['priority'] = '100'
         with pytest.raises(languages.LanguageConfigError):
             languages.Language('id', vals)
-
 
     def test_missing_files(self):
         vals = self.__language_dict()

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -613,13 +613,13 @@ class ProblemConfig(ProblemAspect):
             self._data['license'] = self._data['license'].lower()
 
         # Ugly backwards compatibility hack
-        if 'name' in self._data and not type(self._data['name']) is dict:
+        if 'name' in self._data and not isinstance(self._data['name'], dict):
             self._data['name'] = {'': self._data['name']}
 
         for field, default in copy.deepcopy(ProblemConfig._OPTIONAL_CONFIG).items():
             if not field in self._data:
                 self._data[field] = default
-            elif type(default) is dict and type(self._data[field]) is dict:
+            elif isinstance(default, dict) and isinstance(self._data[field], dict):
                 self._data[field] = dict(list(default.items()) + list(self._data[field].items()))
 
         self._origdata = copy.deepcopy(self._data)
@@ -715,7 +715,7 @@ class ProblemConfig(ProblemAspect):
                     self.error("Invalid parameter '%s' for custom validation" % param)
 
         # Check limits
-        if type(self._data['limits']) is not dict:
+        if not isinstance(self._data['limits'], dict):
             self.error('Limits key in problem.yaml must specify a dict')
             self._data['limits'] = ProblemConfig._OPTIONAL_CONFIG['limits']
 


### PR DESCRIPTION
This PR makes us build a debian which contains modules for both python2 and python3. While fixing the test errors I did a quick cleanup of the type comparisons. Note that one check was specifically designed to look for a "long" type. This type does not exist in python 3. I removed this check, and added a check for string types instead in `test_languages.py`.  

This should pass CI once #147 is merged.
I think this could be consider a part of #116
