### PR TITLE
Add F# to languages.yaml

### DIFF
--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -122,6 +122,13 @@ cobol:
     compile: '/usr/bin/cobc -o {binary} -g -O2 -std=default -free -x -static {files}'
     run: '{binary}'
 
+fsharp:
+    name: 'F#'
+    priority: 675
+    files: '*.fs'
+    compile: '/usr/bin/fsharpc --out:{binary}.exe --optimize+ -r:System.Numerics {files}'
+    run: '/usr/bin/mono {binary}.exe'
+
 go:
     name: 'Go'
     priority: 400


### PR DESCRIPTION
This adds F# to languages to languages.yaml.

I tried to figure out if I need to do anything more to add the language to problemtools, but couldn't find any documentation or references in the code to give hints. 