### PR TITLE
Replace dependency on texlive-latex-recommended with texlive-plain-generic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
             texlive-fonts-recommended \
             texlive-lang-cyrillic \
             texlive-latex-extra \
-            texlive-latex-recommended \
+            texlive-plain-generic \
             tidy \
             vim
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The dependencies needed to *build/install* problemtools can be installed with:
 
 And the dependencies needed to *run* problemtools can be installed with:
 
-    sudo apt install ghostscript libgmpxx4ldbl python-minimal python-pkg-resources python-plastex python-yaml texlive-fonts-recommended texlive-generic-recommended texlive-lang-cyrillic texlive-latex-extra texlive-latex-recommended tidy
+    sudo apt install ghostscript libgmpxx4ldbl python-minimal python-pkg-resources python-plastex python-yaml texlive-fonts-recommended texlive-generic-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy
 
 ### Fedora
 

--- a/admin/docker/Dockerfile.minimal
+++ b/admin/docker/Dockerfile.minimal
@@ -30,7 +30,7 @@ RUN apt update && \
         texlive-generic-recommended \
         texlive-lang-cyrillic \
         texlive-latex-extra \
-        texlive-latex-recommended \
+        texlive-plain-generic \
         tidy
 
 RUN mkdir -p /usr/local/artifacts

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/Kattis/problemtools
 
 Package: kattis-problemtools
 Architecture: any
-Depends: ${shlibs:Depends}, ${python:Depends}, ${python3:Depends}, ${misc:Depends}, python-yaml, python-plastex, python-pkg-resources, texlive-latex-recommended, texlive-fonts-recommended, texlive-latex-extra, texlive-generic-recommended, texlive-lang-cyrillic, tidy, ghostscript
+Depends: ${shlibs:Depends}, ${python:Depends}, ${python3:Depends}, ${misc:Depends}, python-yaml, python-plastex, python-pkg-resources, texlive-plain-generic, texlive-fonts-recommended, texlive-latex-extra, texlive-generic-recommended, texlive-lang-cyrillic, tidy, ghostscript
 Recommends: gcc, g++
 Description: Kattis Problem Tools
  These are tools to manage and verify problem packages in the


### PR DESCRIPTION
texlive-latex-recommended is a transitional dummy package which is removed
in eoan (19.10). It only depends on texlive-plain-generic.

See https://packages.ubuntu.com/cosmic/texlive-generic-recommended

Fixes #155

