### PR TITLE
Remove texlive-generic-recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The dependencies needed to *build/install* problemtools can be installed with:
 
 And the dependencies needed to *run* problemtools can be installed with:
 
-    sudo apt install ghostscript libgmpxx4ldbl python-minimal python-pkg-resources python-plastex python-yaml texlive-fonts-recommended texlive-generic-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy
+    sudo apt install ghostscript libgmpxx4ldbl python-minimal python-pkg-resources python-plastex python-yaml texlive-fonts-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy
 
 ### Fedora
 

--- a/admin/docker/Dockerfile.minimal
+++ b/admin/docker/Dockerfile.minimal
@@ -27,7 +27,6 @@ RUN apt update && \
         python3-minimal \
         python3-yaml \
         texlive-fonts-recommended \
-        texlive-generic-recommended \
         texlive-lang-cyrillic \
         texlive-latex-extra \
         texlive-plain-generic \

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/Kattis/problemtools
 
 Package: kattis-problemtools
 Architecture: any
-Depends: ${shlibs:Depends}, ${python:Depends}, ${python3:Depends}, ${misc:Depends}, python-yaml, python-plastex, python-pkg-resources, texlive-plain-generic, texlive-fonts-recommended, texlive-latex-extra, texlive-generic-recommended, texlive-lang-cyrillic, tidy, ghostscript
+Depends: ${shlibs:Depends}, ${python:Depends}, ${python3:Depends}, ${misc:Depends}, python-yaml, python-plastex, python-pkg-resources, texlive-plain-generic, texlive-fonts-recommended, texlive-latex-extra, texlive-lang-cyrillic, tidy, ghostscript
 Recommends: gcc, g++
 Description: Kattis Problem Tools
  These are tools to manage and verify problem packages in the


### PR DESCRIPTION
texlive-generic-recommended is (also) a dummy transitional package replaced by texlive-plain-generic. It is not available in 19.10 (eoan)

See https://packages.ubuntu.com/cosmic/texlive-generic-recommended