### PR TITLE
remove cgi, which seems to be causing problems

### DIFF
--- a/problemtools/ProblemPlasTeX/ProblemsetMacros.py
+++ b/problemtools/ProblemPlasTeX/ProblemsetMacros.py
@@ -2,7 +2,6 @@ import sys
 import os
 import os.path
 import codecs
-import cgi
 from plasTeX.DOM import Node
 from plasTeX.Base import Command
 from plasTeX.Base import DimenCommand
@@ -46,9 +45,7 @@ class sampletable(Command):
     args = 'header1 file1:str header2 file2:str'
 
     def read_sample_file(self, filename):
-        data = open(filename, 'rb').read().decode('utf8')
-        data = cgi.escape(data)
-        return data
+        return open(filename, 'rb').read().decode('utf8')
 
     def invoke(self, tex):
         res = Command.invoke(self, tex)
@@ -82,12 +79,12 @@ class sampletableinteractive(Command):
             line = line[1:]
             if mode != cur_mode:
                 if cur_mode: messages.append({'mode': cur_mode,
-                                              'data': cgi.escape('\n'.join(cur_msg))})
+                                              'data': '\n'.join(cur_msg)})
                 cur_msg = []
             cur_msg.append(line)
             cur_mode = mode
         if cur_mode: messages.append({'mode': cur_mode,
-                                      'data': cgi.escape('\n'.join(cur_msg))})
+                                      'data': '\n'.join(cur_msg)})
         return messages
 
     def invoke(self, tex):

--- a/problemtools/ProblemPlasTeX/ProblemsetMacros.py
+++ b/problemtools/ProblemPlasTeX/ProblemsetMacros.py
@@ -1,12 +1,20 @@
 import sys
 import os
 import os.path
-import codecs
+import io
 from plasTeX.DOM import Node
 from plasTeX.Base import Command
 from plasTeX.Base import DimenCommand
 from plasTeX.Logging import getLogger
 import plasTeX.Packages.graphics as graphics
+
+if sys.version_info.major == 2:
+    import cgi
+    def plastex_escape(s):
+        return cgi.escape(s)
+else:
+    def plastex_escape(s):
+        return s
 
 log = getLogger()
 status = getLogger('status')
@@ -45,7 +53,9 @@ class sampletable(Command):
     args = 'header1 file1:str header2 file2:str'
 
     def read_sample_file(self, filename):
-        return open(filename, 'rb').read().decode('utf8')
+        data = io.open(filename, 'r', encoding='utf-8').read()
+        data = plastex_escape(data)
+        return data
 
     def invoke(self, tex):
         res = Command.invoke(self, tex)
@@ -67,7 +77,7 @@ class sampletableinteractive(Command):
     args = 'header read write file:str'
 
     def read_sample_interaction(self, filename):
-        data = open(filename, 'rb').read().decode('utf8')
+        data = io.open(filename, 'r', encoding='utf-8').read()
         messages = []
         cur_msg = []
         cur_mode = None
@@ -79,12 +89,12 @@ class sampletableinteractive(Command):
             line = line[1:]
             if mode != cur_mode:
                 if cur_mode: messages.append({'mode': cur_mode,
-                                              'data': '\n'.join(cur_msg)})
+                                              'data': plastex_escape('\n'.join(cur_msg))})
                 cur_msg = []
             cur_msg.append(line)
             cur_mode = mode
         if cur_mode: messages.append({'mode': cur_mode,
-                                      'data': '\n'.join(cur_msg)})
+                                      'data': plastex_escape('\n'.join(cur_msg))})
         return messages
 
     def invoke(self, tex):

--- a/problemtools/ProblemPlasTeX/listingsutf8.py
+++ b/problemtools/ProblemPlasTeX/listingsutf8.py
@@ -2,6 +2,9 @@ from plasTeX.Base import Command
 from plasTeX.Logging import getLogger
 
 import os
+import io
+
+import ProblemsetMacros
 
 log = getLogger()
 
@@ -12,7 +15,9 @@ class lstinputlisting(Command):
     args = '* [ options:dict ] file:str'
 
     def read_file(self, filename):
-        return open(filename, 'rb').read().decode('utf8')
+        data = io.open(filename, 'r', encoding='utf-8').read()
+        data = ProblemsetMacros.plastex_escape(data)
+        return data
 
     def invoke(self, tex):
         res = Command.invoke(self, tex)

--- a/problemtools/ProblemPlasTeX/listingsutf8.py
+++ b/problemtools/ProblemPlasTeX/listingsutf8.py
@@ -1,7 +1,6 @@
 from plasTeX.Base import Command
 from plasTeX.Logging import getLogger
 
-import cgi
 import os
 
 log = getLogger()
@@ -13,9 +12,7 @@ class lstinputlisting(Command):
     args = '* [ options:dict ] file:str'
 
     def read_file(self, filename):
-        data = open(filename, 'r').read().decode('utf8')
-        data = cgi.escape(data)
-        return data
+        return open(filename, 'rb').read().decode('utf8')
 
     def invoke(self, tex):
         res = Command.invoke(self, tex)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -300,7 +300,8 @@ class TestCaseGroup(ProblemAspect):
         configfile = os.path.join(self._datadir, 'testdata.yaml')
         if os.path.isfile(configfile):
             try:
-                self.config = yaml.safe_load(file(configfile))
+                with open(configfile) as f:
+                    self.config = yaml.safe_load(f)
             except Exception as e:
                 self.error(e)
                 self.config = {}


### PR DESCRIPTION
Fixes #162

cgi.escape() would cause "<" to become "`&lt;`", which would then get
rendered by plasTeX as "`&amp;lt;`". Removing cgi.escape() fixes the
issue.

One other change rolled into this commit is a necessary change to
listingsutf8.py to read input files properly.