### PR TITLE
Use pypy3 for python3 in Dockerfile.icpc

### DIFF
--- a/admin/docker/Dockerfile.icpc
+++ b/admin/docker/Dockerfile.icpc
@@ -12,13 +12,16 @@ LABEL maintainer="austrin@kattis.com"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install C++, Java, PyPy and Python 3
+# Install C++, Java, and PyPy 2/3 via their ppa repository
 RUN apt update && \
+    apt install -y software-properties-common && \
+    add-apt-repository ppa:pypy/ppa && \
+    apt update && \
     apt install -y \
         g++ \
         openjdk-11-jdk \
         pypy \
-        python3
+        pypy3
 
 # Install Kotlin
 WORKDIR /usr/local
@@ -34,6 +37,10 @@ RUN echo " \n\
 python2: \n\
     name: 'Python 2 w/PyPy'\n\
     run: '/usr/bin/pypy \"{mainfile}\"'\n\
+ \n\
+python3: \n\
+    name: 'Python 3 w/PyPy'\n\
+    run: '/usr/bin/pypy3 \"{mainfile}\"'\n\
  \n\
 kotlin: \n\
     compile: '/usr/local/bin/kotlinc -d {path}/ -- {files}' \n\


### PR DESCRIPTION
Since Kattis uses PyPy for [Python 3](https://open.kattis.com/help/python3), there are big performance differences in the problemtools image which uses python3. Using pypy3 in a Docker image will more accurately reflect how the problem will perform in the Kattis system, so I changed the Dockerfile.icpc to support this.

This change depends on the PyPy PPA, but as it's blessed by the PyPy developers I don't see that as an issue.