### PR TITLE
Allow x.in and y.ans as test data group names.

### DIFF
--- a/problemtools/templates/latex/problemset.cls
+++ b/problemtools/templates/latex/problemset.cls
@@ -95,6 +95,7 @@
                                    {\normalfont\large\sf\bfseries}}
 \newenvironment{Input}{\section*{Input}}{}
 \newenvironment{Output}{\section*{Output}}{}
+\newenvironment{Interaction}{\section*{Interaction}}{}
 
 \renewcommand\subsection{\@startsection{subsection}{2}{\z@}%
                                      {-3.55ex}%


### PR DESCRIPTION
fixes #169 