### PR TITLE
Init submodule from root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-all:
+all: checktestdata
 	make -C support
 
-builddeb:
+builddeb: checktestdata
 	dpkg-buildpackage -us -uc -tc -b
+
+checktestdata: support/checktestdata/bootstrap
+
+support/checktestdata/bootstrap:
+	git submodule update --init


### PR DESCRIPTION
Fixes: #79

Apparently relying on `dpkg-buildpackage` to run `support/Makefile` early
enough is not reliable. I haven't dug into why but rather added
init:ing the checkdata submodule to the root `Makefile`'s targets. Worst case, adding it for the `all` target is redundant given the `support/Makefile`

Tested as far as running `make builddeb` in clean clone from inside a `ubuntu:18.04` docker image (running on my macbook).