### PR TITLE
Update ubuntu; move to python3; other updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.7
   - 3.7
 
 script: py.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 MAINTAINER austrin@kattis.com
 
@@ -14,10 +14,10 @@ RUN apt-get update && \
             libgmp10 \
             libgmpxx4ldbl \
             openjdk-8-jdk \
-            python-minimal \
-            python-pip \
-            python-plastex \
-            python-yaml \
+            python3-minimal \
+            python3-pip \
+            python3-plastex \
+            python3-yaml \
             sudo \
             texlive-fonts-recommended \
             texlive-lang-cyrillic \
@@ -26,4 +26,4 @@ RUN apt-get update && \
             tidy \
             vim
 
-RUN pip install git+https://github.com/kattis/problemtools
+RUN pip3 install git+https://github.com/ghamerly/problemtools@move-to-py3

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN apt-get update && \
             tidy \
             vim
 
-RUN pip3 install git+https://github.com/ghamerly/problemtools@move-to-py3
+RUN pip3 install git+https://github.com/kattis/problemtools

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ There are four recommended ways of installing and running problemtools.
 
 Run
 ```
-pip install git+https://github.com/kattis/problemtools
+pip3 install git+https://github.com/kattis/problemtools
 ```
 
 Or if you don't want a system-wide installation,
 ```
-pip install --user git+https://github.com/kattis/problemtools
+pip3 install --user git+https://github.com/kattis/problemtools
 ```
 With this second option, in order to get the command line scripts, you need
 to make sure that the local user bin path used (e.g., on Linux,
@@ -153,18 +153,18 @@ problemtools' configuration:
 
 1. `languages.yaml`.  Use it to override problemtools' default
    programming language configuration.  For instance, while the
-   problemtools default is to use the CPython `/usr/bin/python2`
-   interpreter for Python 2, many contests, as well as the Kattis
-   online judge, use Pypy as the interpreter for Python 2.  To change
+   problemtools default is to use the CPython `/usr/bin/python3`
+   interpreter for Python 3, many contests, as well as the Kattis
+   online judge, use Pypy as the interpreter for Python 3.  To change
    this on your machine, you can simply place a file
    `/etc/kattis/problemtools/languages.yaml` (or
    `~/.config/problemtools/languages.yaml` if you only want to make the
    change for your user) containing the following:
 
    ```yaml
-   python2:
-      name: 'Python 2 w/Pypy'
-      run: '/usr/bin/pypy "{mainfile}"'
+   python3:
+      name: 'Python 3 w/Pypy'
+      run: '/usr/bin/pypy3 "{mainfile}"'
    ```
    Here, overriding the name of the language is not strictly
    necessary, but it is often helpful to clearly indicate that Pypy is
@@ -196,14 +196,14 @@ problemtools' configuration:
 
 ## Requirements and compatibility
 
-To build and run the tools, you need Python 2 with the YAML and PlasTeX libraries,
+To build and run the tools, you need Python 3 with the YAML and PlasTeX libraries,
 and a LaTeX installation.
 
 ### Ubuntu
 
 The dependencies needed to *build/install* problemtools can be installed with:
 
-    sudo apt install automake g++ make libboost-regex-dev libgmp-dev libgmp10 libgmpxx4ldbl python python-pytest python-setuptools python-yaml
+    sudo apt install automake g++ make libboost-regex-dev libgmp-dev libgmp10 libgmpxx4ldbl python3 python3-pytest python3-setuptools python3-yaml python3-plastex
 
 And the dependencies needed to *run* problemtools can be installed with:
 
@@ -213,11 +213,11 @@ And the dependencies needed to *run* problemtools can be installed with:
 
 On Fedora, these dependencies can be installed with:
 
-    sudo dnf install boost-regex gcc gmp-devel gmp-c++ python2 python2-pyyaml texlive-latex texlive-collection-fontsrecommended texlive-fancyhdr texlive-subfigure texlive-wrapfig texlive-import texlive-ulem texlive-xifthen texlive-overpic texlive-pbox tidy ghostscript
+    sudo dnf install boost-regex gcc gmp-devel gmp-c++ python3 python3-pyyaml texlive-latex texlive-collection-fontsrecommended texlive-fancyhdr texlive-subfigure texlive-wrapfig texlive-import texlive-ulem texlive-xifthen texlive-overpic texlive-pbox tidy ghostscript
 
 Followed by:
 
-    pip2 install --user plastex
+    pip3 install --user plastex
 
 ### Other platforms
 

--- a/admin/docker/Dockerfile.build
+++ b/admin/docker/Dockerfile.build
@@ -5,7 +5,7 @@
 # version of problemtools to be built (default is latest version of
 # develop branch on GitHub)
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="austrin@kattis.com"
 
@@ -29,10 +29,7 @@ RUN apt update && \
         python3-pytest \
         python3-setuptools \
         python3-yaml \
-        python \
-        python-pytest \
-        python-setuptools \
-        python-yaml
+        python3-setuptools
 
 RUN mkdir -p /usr/local/problemtools_build
 

--- a/admin/docker/Dockerfile.full
+++ b/admin/docker/Dockerfile.full
@@ -20,6 +20,7 @@ RUN apt-get update && \
             swi-prolog \
             scala \
             sbcl \
+            nodejs \
             ocaml-nox \
             rustc \
    ;

--- a/admin/docker/Dockerfile.icpc
+++ b/admin/docker/Dockerfile.icpc
@@ -18,7 +18,7 @@ RUN apt update && \
         g++ \
         openjdk-11-jdk \
         pypy \
-        python3
+        pypy3
 
 # Install Kotlin
 WORKDIR /usr/local
@@ -28,12 +28,17 @@ RUN ln -s /usr/local/kotlinc/bin/* bin/
 
 # Reconfigure problemtools:
 # - Use PyPy for Python 2
+# - Use PyPy for Python 3
 # - Use /usr/local/bin rather than /usr/bin for Kotlin
 RUN mkdir -p /etc/kattis/problemtools
 RUN echo " \n\
 python2: \n\
     name: 'Python 2 w/PyPy'\n\
     run: '/usr/bin/pypy \"{mainfile}\"'\n\
+ \n\
+python3: \n\
+    name: 'Python 3 w/PyPy'\n\
+    run: '/usr/bin/pypy3 \"{mainfile}\"'\n\
  \n\
 kotlin: \n\
     compile: '/usr/local/bin/kotlinc -d {path}/ -- {files}' \n\

--- a/admin/docker/Dockerfile.minimal
+++ b/admin/docker/Dockerfile.minimal
@@ -1,6 +1,6 @@
 # Minimalistic problemtools docker image, containing only problemtools
 # and its dependencies, no languages (except whichever are
-# dependencies of problemtools, e.g. Python 2)
+# dependencies of problemtools, e.g. Python 3)
 #
 # Build requirements:
 # - The problemtools .deb package must be available from the host file
@@ -10,7 +10,7 @@
 #    PROBLEMTOOLS_VERSION but this is not checked.)
 
 ARG PROBLEMTOOLS_VERSION=develop
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="austrin@kattis.com"
 
@@ -20,12 +20,10 @@ RUN apt update && \
     apt install -y \
         ghostscript \
         libgmpxx4ldbl \
-        python-minimal \
         python-pkg-resources \
-        python-plastex \
-        python-yaml \
         python3-minimal \
         python3-yaml \
+        python3-plastex \
         texlive-fonts-recommended \
         texlive-lang-cyrillic \
         texlive-latex-extra \

--- a/bin/problem2html.sh
+++ b/bin/problem2html.sh
@@ -7,4 +7,4 @@
 
 export PYTHONPATH
 PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
-exec python2 -m problemtools.problem2html "$@"
+exec python3 -m problemtools.problem2html "$@"

--- a/bin/problem2pdf.sh
+++ b/bin/problem2pdf.sh
@@ -7,4 +7,4 @@
 
 export PYTHONPATH
 PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
-exec python2 -m problemtools.problem2pdf "$@"
+exec python3 -m problemtools.problem2pdf "$@"

--- a/bin/verifyproblem.sh
+++ b/bin/verifyproblem.sh
@@ -7,4 +7,4 @@
 
 export PYTHONPATH
 PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
-exec python2 -m problemtools.verifyproblem "$@"
+exec python3 -m problemtools.verifyproblem "$@"

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: kattis-problemtools
 Section: devel
 Priority: optional
 Maintainer: Per Austrin <austrin@kattis.com>
-Build-Depends: debhelper (>= 8.0.0), g++ (>= 4.8), dh-python, python3, python3-setuptools, python3-pytest, python3-yaml, python (>= 2.6.6-3~), python-setuptools, python-pytest, python-yaml, libboost-regex-dev, libgmp-dev, automake, autoconf
+Build-Depends: debhelper (>= 8.0.0), g++ (>= 4.8), dh-python, python3, python3-setuptools, python3-pytest, python3-yaml, python3-setuptools, python3-pytest, libboost-regex-dev, libgmp-dev, automake, autoconf
 Standards-Version: 3.9.4
 Homepage: https://github.com/Kattis/problemtools
 
 Package: kattis-problemtools
 Architecture: any
-Depends: ${shlibs:Depends}, ${python:Depends}, ${python3:Depends}, ${misc:Depends}, python-yaml, plastex, python3-plastex, python-pkg-resources, texlive-plain-generic, texlive-fonts-recommended, texlive-latex-extra, texlive-lang-cyrillic, tidy, ghostscript
+Depends: ${shlibs:Depends}, ${python3:Depends}, ${misc:Depends}, python3-plastex, python-pkg-resources, texlive-plain-generic, texlive-fonts-recommended, texlive-latex-extra, texlive-lang-cyrillic, tidy, ghostscript
 Recommends: gcc, g++
 Description: Kattis Problem Tools
  These are tools to manage and verify problem packages in the

--- a/debian/rules
+++ b/debian/rules
@@ -11,12 +11,5 @@ export PYBUILD_AFTER_CLEAN=make -C support distclean
 export PYBUILD_TEST_PYTEST=1
 export no_proxy=github.com
 
-# FIXME: while we're building for both py2 and py3, we get a clash
-# with the CLI scripts.  The following Workaround puts the py3 CLI
-# scripts somewhere else where they don't do any harm, so that the
-# main CLI scripts are the py2 ones for now.  Once we drop py2 support
-# we also drop this line.
-export PYBUILD_INSTALL_ARGS_python3=--install-scripts=/usr/lib/problemtools/bin/
-
 %:
-	dh $@ --with python3,python2 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild

--- a/examples/different/input_format_validators/validate.py
+++ b/examples/different/input_format_validators/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 from sys import stdin
 import sys
 import re

--- a/examples/different/submissions/accepted/different.js
+++ b/examples/different/submissions/accepted/different.js
@@ -1,9 +1,14 @@
-var line;
+const readline = require('readline');
 
-while (line = readline()) {
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout
+});
+
+rl.on('line', (line) => {
     var nums = line.split(' ');
     var a = parseInt(nums[0]);
     var b = parseInt(nums[1]);
     var res = Math.abs(a - b);
-    print(res);
-}
+    console.log(res);
+});

--- a/examples/different/submissions/accepted/different.py
+++ b/examples/different/submissions/accepted/different.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 import sys
 
 for line in sys.stdin:

--- a/examples/different/submissions/accepted/different_py2.py
+++ b/examples/different/submissions/accepted/different_py2.py
@@ -7,4 +7,3 @@ for line in sys.stdin:
     a = int(ab[0])
     b = int(ab[1])
     print abs(a-b)
-

--- a/examples/different/submissions/accepted/different_py3.py
+++ b/examples/different/submissions/accepted/different_py3.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/examples/different/submissions/slow_accepted/different_slow.py
+++ b/examples/different/submissions/slow_accepted/different_slow.py
@@ -1,0 +1,15 @@
+#! /usr/bin/python3
+
+import sys
+
+for line in sys.stdin:
+    ab = line.split()
+    a = int(ab[0])
+    b = int(ab[1])
+    # needless loop just to be slow
+    x = a
+    for _ in range(100000000):
+        x += 1
+    diff = abs(a-b) + x - x
+
+    print(diff)

--- a/examples/guess/input_format_validators/validate.py
+++ b/examples/guess/input_format_validators/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 from sys import stdin
 import sys
 import re

--- a/examples/guess/submissions/wrong_answer/guess.py
+++ b/examples/guess/submissions/wrong_answer/guess.py
@@ -1,3 +1,3 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
-print "500"
+print("500")

--- a/examples/hello/input_format_validators/validate.py
+++ b/examples/hello/input_format_validators/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 from sys import stdin
 import sys
 

--- a/examples/hello/submissions/accepted/hello.py
+++ b/examples/hello/submissions/accepted/hello.py
@@ -1,1 +1,3 @@
-print 'Hello World!'
+#!/usr/bin/env python3
+
+print('Hello World!')

--- a/problemtools/ProblemPlasTeX/ProblemsetMacros.py
+++ b/problemtools/ProblemPlasTeX/ProblemsetMacros.py
@@ -8,14 +8,6 @@ from plasTeX.Base import DimenCommand
 from plasTeX.Logging import getLogger
 import plasTeX.Packages.graphics as graphics
 
-if sys.version_info.major == 2:
-    import cgi
-    def plastex_escape(s):
-        return cgi.escape(s)
-else:
-    def plastex_escape(s):
-        return s
-
 log = getLogger()
 status = getLogger('status')
 
@@ -53,9 +45,7 @@ class sampletable(Command):
     args = 'header1 file1:str header2 file2:str'
 
     def read_sample_file(self, filename):
-        data = io.open(filename, 'r', encoding='utf-8').read()
-        data = plastex_escape(data)
-        return data
+        return io.open(filename, 'r', encoding='utf-8').read()
 
     def invoke(self, tex):
         res = Command.invoke(self, tex)
@@ -89,12 +79,12 @@ class sampletableinteractive(Command):
             line = line[1:]
             if mode != cur_mode:
                 if cur_mode: messages.append({'mode': cur_mode,
-                                              'data': plastex_escape('\n'.join(cur_msg))})
+                                              'data': '\n'.join(cur_msg)})
                 cur_msg = []
             cur_msg.append(line)
             cur_mode = mode
         if cur_mode: messages.append({'mode': cur_mode,
-                                      'data': plastex_escape('\n'.join(cur_msg))})
+                                      'data': '\n'.join(cur_msg)})
         return messages
 
     def invoke(self, tex):

--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -154,8 +154,8 @@ javascript:
     name: 'JavaScript'
     priority: 500
     files: '*.js'
-    compile: '/usr/bin/js24 -c {files}'
-    run: '/usr/bin/js24 "{mainfile}"'
+    compile: '/usr/bin/nodejs -c {files}'
+    run: '/usr/bin/nodejs "{mainfile}"'
 
 kotlin:
     name: 'Kotlin'

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -1,16 +1,14 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import re
 import os.path
 import sys
 import string
-from string import Template
-from optparse import OptionParser
+import optparse
 from .ProblemPlasTeX import ProblemRenderer
 from .ProblemPlasTeX import ProblemsetMacros
-from plasTeX.TeX import TeX
-from plasTeX.Logging import getLogger, disableLogging
+import plasTeX.TeX
+import plasTeX.Logging
 import logging
 import subprocess
 from . import template
@@ -20,15 +18,15 @@ def convert(problem, options=None):
     problem = os.path.realpath(problem)
 
     problembase = os.path.splitext(os.path.basename(problem))[0]
-    destdir = Template(options.destdir).safe_substitute(problem=problembase)
-    destfile = Template(options.destfile).safe_substitute(problem=problembase)
-    imgbasedir = Template(options.imgbasedir).safe_substitute(problem=problembase)
+    destdir = string.Template(options.destdir).safe_substitute(problem=problembase)
+    destfile = string.Template(options.destfile).safe_substitute(problem=problembase)
+    imgbasedir = string.Template(options.imgbasedir).safe_substitute(problem=problembase)
 
     if options.quiet:
-        disableLogging()
+        plasTeX.Logging.disableLogging()
     else:
-        getLogger().setLevel(eval("logging." + options.loglevel.upper()))
-        getLogger('status').setLevel(eval("logging." + options.loglevel.upper()))
+        plasTeX.Logging.getLogger().setLevel(eval("logging." + options.loglevel.upper()))
+        plasTeX.Logging.getLogger('status').setLevel(eval("logging." + options.loglevel.upper()))
 
     texfile = problem
     # Set up template if necessary
@@ -39,7 +37,7 @@ def convert(problem, options=None):
 
         # Setup parser and renderer etc
 
-        tex = TeX(myfile=texfile)
+        tex = plasTeX.TeX.TeX(myfile=texfile)
 
         ProblemsetMacros.init(tex)
 
@@ -135,16 +133,16 @@ class ConvertOptions:
 
 def main():
     options = ConvertOptions()
-    optparse = OptionParser(usage="usage: %prog [options] problem")
+    parser = optparse.OptionParser(usage="usage: %prog [options] problem")
     for (dest, action, short, long, help) in ConvertOptions.available:
         if (action == 'store'):
             help += ' default: "%s"' % options.__dict__[dest]
-        optparse.add_option(short, long, dest=dest, help=help, action=action)
+        parser.add_option(short, long, dest=dest, help=help, action=action)
 
-    (options, args) = optparse.parse_args(values=options)
+    (options, args) = parser.parse_args(values=options)
 
     if len(args) != 1:
-        optparse.print_help()
+        parser.print_help()
         sys.exit(1)
 
     texfile = args[0]

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 import re
@@ -39,11 +39,7 @@ def convert(problem, options=None):
 
         # Setup parser and renderer etc
 
-        # Python 2 compatibility: the second keyword argument for th TeX
-        # class changed name from file to myfile in Python 3 version.  When
-        # Python 2 compatibility is dropped, change this to "tex =
-        # TeX(myfile=texfile)".
-        tex = TeX(None, texfile)
+        tex = TeX(myfile=texfile)
 
         ProblemsetMacros.init(tex)
 

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import re
 import os.path

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -1,24 +1,20 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
-import re
 import os.path
 import shutil
-import sys
 import string
-from string import Template
-from optparse import OptionParser
-import logging
+import argparse
 import subprocess
 from . import template
 
 
 def convert(problem, options=None):
-    if options == None:
+    if options is None:
         options = ConvertOptions()
 
     problem = os.path.realpath(problem)
     problembase = os.path.splitext(os.path.basename(problem))[0]
-    destfile = Template(options.destfile).safe_substitute(problem=problembase)
+    destfile = string.Template(options.destfile).safe_substitute(problem=problembase)
 
     texfile = problem
     # Set up template if necessary
@@ -56,41 +52,32 @@ def convert(problem, options=None):
 class ConvertOptions:
     available = [
         ['destfile', 'store', '-o', '--output',
-         "output file name."],
+         "output file name", '${problem}.pdf'],
         ['quiet', 'store_true', '-q', '--quiet',
-         "quiet."],
+         "quiet", False],
         ['title', 'store', '-T', '--title',
-         'set title (only used when there is no pre-existing template and -h not set).'],
+         'set title (only used when there is no pre-existing template and -h not set)',
+         'Problem Name'],
         ['language', 'store', '-l', '--language',
-         'choose alternate language (2-letter code).'],
+         'choose alternate language (2-letter code)', ''],
         ['nopdf', 'store_true', '-n', '--no-pdf',
-         'run pdflatex in -draftmode'],
+         'run pdflatex in -draftmode', False],
         ]
 
     def __init__(self):
-        self.destfile = "${problem}.pdf"
-        self.title = "Problem Name"
-        self.quiet = False
-        self.language = ""
-        self.nopdf = False
+        for (dest, _, _, _, _, default) in ConvertOptions.available:
+            setattr(self, dest, default)
 
 
 def main():
-    options = ConvertOptions()
-    optparse = OptionParser(usage="usage: %prog [options] problem")
-    for (dest, action, short, long, help) in ConvertOptions.available:
-        if (action == 'store'):
-            help += ' default: "%s"' % options.__dict__[dest]
-        optparse.add_option(short, long, dest=dest, help=help, action=action)
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    (options, args) = optparse.parse_args(values=options)
+    for (dest, action, short, _long, _help, default) in ConvertOptions.available:
+        parser.add_argument(short, _long, dest=dest, help=_help, action=action, default=default)
+    parser.add_argument('problem', help='the problem to convert')
 
-    if len(args) != 1:
-        optparse.print_help()
-        sys.exit(1)
-
-    texfile = args[0]
-    convert(texfile, options)
+    options = parser.parse_args()
+    convert(options.problem, options)
 
 
 if __name__ == '__main__':

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -1,6 +1,5 @@
 """Abstract base class for programs.
 """
-from __future__ import print_function
 import os
 from . import limit
 import resource

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-import os
 import re
 import os.path
 import glob
@@ -10,7 +8,7 @@ import shutil
 # For backwards compatibility, remove in bright and shiny future.
 def detect_version(problemdir, problemtex):
     # Check for 0.1 - lack of \problemname
-    if open(problemtex).read().find('\problemname') < 0:
+    if open(problemtex).read().find(r'\problemname') < 0:
         return '0.1'
     return ''  # Current
 

--- a/problemtools/tests/test_languages.py
+++ b/problemtools/tests/test_languages.py
@@ -145,7 +145,7 @@ class Language_test(TestCase):
 
     def test_invalid_run(self):
         vals = self.__language_dict()
-        vals['run'] = ['python2', '{mainfile}']
+        vals['run'] = ['python3', '{mainfile}']
         with pytest.raises(languages.LanguageConfigError):
             languages.Language('id', vals)
         vals['run'] = 'echo {nonexistent}'

--- a/problemtools/update_from_old_problemformat.py
+++ b/problemtools/update_from_old_problemformat.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-from optparse import OptionParser
+import optparse
 import glob
-import os
+import os.path
 import yaml
 
 
@@ -45,11 +44,11 @@ def update(problemdir):
         yaml_changed = True
 
     if yaml_changed:
-        open(probyaml, 'w').write(yaml.dump(config, default_flow_style = False, allow_unicode = True))
+        open(probyaml, 'w').write(yaml.dump(config, default_flow_style=False, allow_unicode=True))
 
 
 if __name__ == '__main__':
-    parser = OptionParser(usage="usage: %prog problems")
+    parser = optparse.OptionParser(usage="usage: %prog problems")
     (options, args) = parser.parse_args()
     if not args:
         parser.print_help()

--- a/problemtools/update_from_old_problemformat.py
+++ b/problemtools/update_from_old_problemformat.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import optparse
+import argparse
 import glob
 import os.path
 import yaml
@@ -18,13 +18,13 @@ def update(problemdir):
 
     if 'name' in config:
         print('Move problem name "%s" to these problem statement files: %s' % (config['name'], stmts))
-        
+
         for f in stmts:
             stmt = open(f, 'r').read()
             if stmt.find('\\problemname{') != -1:
                 print('   Statement %s already has a problemname, skipping' % f)
                 continue
-            newstmt = '\problemname{%s}\n\n%s' % (config['name'], stmt)
+            newstmt = '\\problemname{%s}\n\n%s' % (config['name'], stmt)
             open(f, 'w').write(newstmt)
         del config['name']
         yaml_changed = True
@@ -48,15 +48,13 @@ def update(problemdir):
 
 
 if __name__ == '__main__':
-    parser = optparse.OptionParser(usage="usage: %prog problems")
-    (options, args) = parser.parse_args()
-    if not args:
-        parser.print_help()
-        
-    for dir in args:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('problemdir', nargs='+')
+    options = parser.parse_args()
+
+    for problemdir in options:
         try:
-            print('Updating %s' % dir)
-            update(dir)
+            print('Updating %s' % problemdir)
+            update(problemdir)
         except Exception as e:
             print('Update FAILED: %s' % e)
-

--- a/problemtools/update_from_old_problemformat.py
+++ b/problemtools/update_from_old_problemformat.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     parser.add_argument('problemdir', nargs='+')
     options = parser.parse_args()
 
-    for problemdir in options:
+    for problemdir in options.problemdir:
         try:
             print('Updating %s' % problemdir)
             update(problemdir)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 import glob

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -697,8 +697,8 @@ class ProblemConfig(ProblemAspect):
             self.error("Invalid value for grading.show_test_data_groups: %s" % self._data['grading']['show_test_data_groups'])
         elif self._data['grading']['show_test_data_groups'] and self._data['type'] == 'pass-fail':
             self.error("Showing test data groups is only supported for scoring problems, this is a pass-fail problem")
-        if self._problem.testdata.has_custom_groups() and 'show_test_data_groups' not in self._origdata.get('grading', {}):
-            self.warning("Problem has custom test case groups, but does not specify a value for show_test_data_groups")
+        if self._data['type'] != 'pass-fail' and self._problem.testdata.has_custom_groups() and 'show_test_data_groups' not in self._origdata.get('grading', {}):
+            self.warning("Problem has custom test case groups, but does not specify a value for grading.show_test_data_groups; defaulting to false")
 
         if 'on_reject' in self._data['grading']:
             if self._data['type'] == 'pass-fail' and self._data['grading']['on_reject'] == 'grade':

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 import glob
 import string
 import hashlib
@@ -10,12 +9,13 @@ import signal
 import re
 import shutil
 import logging
-import yaml
 import tempfile
 import sys
 import copy
 import random
-from argparse import ArgumentParser, ArgumentTypeError
+import argparse
+
+import yaml
 
 from . import problem2pdf
 from . import problem2html
@@ -1468,17 +1468,17 @@ def re_argument(s):
         r = re.compile(s)
         return r
     except re.error:
-        raise ArgumentTypeError('%s is not a valid regex' % s)
+        raise argparse.ArgumentTypeError('%s is not a valid regex' % s)
 
 
 def part_argument(s):
     if s not in PROBLEM_PARTS:
-        raise ArgumentTypeError("Invalid problem part specified: %s" % s)
+        raise argparse.ArgumentTypeError("Invalid problem part specified: %s" % s)
     return s
 
 
 def argparser():
-    parser = ArgumentParser(description='Validate a problem package in the Kattis problem format.')
+    parser = argparse.ArgumentParser(description='Validate a problem package in the Kattis problem format.')
     parser.add_argument('-s', '--submission_filter', metavar='SUBMISSIONS',
                         type=re_argument, default=re.compile('.*'),
                         help='run only submissions whose name contains this regex.  The name includes category (accepted, wrong_answer, etc), e.g. "accepted/hello.java" (for a single file submission) or "wrong_answer/hello" (for a directory submission)')

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -381,6 +381,10 @@ class TestCaseGroup(ProblemAspect):
         return next((child for child in self._items if isinstance(child, TestCaseGroup) and os.path.basename(child._datadir) == name), None)
 
 
+    def has_custom_groups(self):
+        return any(group.get_subgroups() for group in self.get_subgroups())
+
+
     def get_score_range(self):
         try:
             score_range = self.config['range']
@@ -618,13 +622,13 @@ class ProblemConfig(ProblemAspect):
         if 'name' in self._data and not isinstance(self._data['name'], dict):
             self._data['name'] = {'': self._data['name']}
 
+        self._origdata = copy.deepcopy(self._data)
+
         for field, default in copy.deepcopy(ProblemConfig._OPTIONAL_CONFIG).items():
             if not field in self._data:
                 self._data[field] = default
             elif isinstance(default, dict) and isinstance(self._data[field], dict):
                 self._data[field] = dict(list(default.items()) + list(self._data[field].items()))
-
-        self._origdata = copy.deepcopy(self._data)
 
         val = self._data['validation'].split()
         self._data['validation-type'] = val[0]
@@ -660,6 +664,8 @@ class ProblemConfig(ProblemAspect):
         for field, value in self._origdata.items():
             if field not in ProblemConfig._OPTIONAL_CONFIG.keys() and field not in ProblemConfig._MANDATORY_CONFIG:
                 self.warning("Unknown field '%s' provided in problem.yaml" % field)
+
+        for field, value in self._data.items():
             if value is None:
                 self.error("Field '%s' provided in problem.yaml but is empty" % field)
                 self._data[field] = ProblemConfig._OPTIONAL_CONFIG.get(field, '')
@@ -691,6 +697,8 @@ class ProblemConfig(ProblemAspect):
             self.error("Invalid value for grading.show_test_data_groups: %s" % self._data['grading']['show_test_data_groups'])
         elif self._data['grading']['show_test_data_groups'] and self._data['type'] == 'pass-fail':
             self.error("Showing test data groups is only supported for scoring problems, this is a pass-fail problem")
+        if self._problem.testdata.has_custom_groups() and 'show_test_data_groups' not in self._origdata.get('grading', {}):
+            self.warning("Problem has custom test case groups, but does not specify a value for show_test_data_groups")
 
         if 'on_reject' in self._data['grading']:
             if self._data['type'] == 'pass-fail' and self._data['grading']['on_reject'] == 'grade':

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 from setuptools.command.bdist_egg import bdist_egg as _bdist_egg
@@ -81,7 +81,6 @@ setup(name='problemtools',
       include_package_data=True,
       install_requires=[
           'PyYAML',
-          'plasTeX<=1.0;python_version<"3"',
           'plasTeX>=2.0;python_version>="3"'
       ],
 #      Temporarily disabled, see setup.cfg

--- a/support/default_grader/default_grader
+++ b/support/default_grader/default_grader
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 
@@ -66,6 +66,6 @@ try:
     else:
         verdict = aggregate_verdicts(verdicts)
     score = aggregate_scores(scores)
-    print '%s %f' % (verdict, score)
+    print('%s %f' % (verdict, score))
 except:
-    print 'JE 0'
+    print('JE')


### PR DESCRIPTION
This PR does a number of updates:
* problemtools scripts now depend only on python3 rather than python2 (e.g. verifyproblem, problem2html, problem2pdf) -- it removes support for running under python2 (NB: it does not remove python2 as a language for submissions)
* update docker images to run under Ubuntu 20.04 (from 18.04)
* uses pypy3 as the Python 3 interpreter in docker images
* replace libmozjs with nodejs in the language configuration

I have built docker images from this branch which are available here for testing:
* https://hub.docker.com/r/hamerly/problemtools-full
* https://hub.docker.com/r/hamerly/problemtools-icpc
* https://hub.docker.com/r/hamerly/problemtools-minimal
* https://hub.docker.com/r/hamerly/problemtools-build

I would appreciate testing and feedback if anyone has time.