### PR TITLE
Don't propagate JE on empty test groups

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -986,6 +986,8 @@ class Graders(ProblemAspect):
         return self._check_res
 
     def grade(self, sub_results, testcasegroup, shadow_result=False):
+        if not sub_results:
+            return ("?", 0.0)
 
         if testcasegroup.config['grading'] == 'default':
             graders = [self._default_grader]


### PR DESCRIPTION
Assuming we have a problem with two test groups `group1` and `group2` then running `verifyproblem foo -d group1/` always results in a `JE` verdict, because the pattern doesn't match any test cases in `group2`.

This fixes it, by returning the `?` verdict for an empty group.

I don't know if this is the best solution.