### PR TITLE
Fix bug in guess output validator

### DIFF
--- a/examples/guess/output_validators/guess_validator/validate.cc
+++ b/examples/guess/output_validators/guess_validator/validate.cc
@@ -62,11 +62,11 @@ void check_case() {
         } else if (diff < 0) {
             cout << "lower\n";
             cout.flush();
-            sol_hi = guess-1;
+            sol_hi = min(sol_hi, guess-1);
         } else {
             cout << "higher\n";
             cout.flush();
-            sol_lo = guess+1;
+            sol_lo = max(sol_lo, guess+1);
         }
     }
     wrong_answer("Didn't get to correct answer in 10 guesses\n");

--- a/examples/guess/output_validators/guess_validator/validate.cc
+++ b/examples/guess/output_validators/guess_validator/validate.cc
@@ -62,10 +62,12 @@ void check_case() {
         } else if (diff < 0) {
             cout << "lower\n";
             cout.flush();
+            // Update the maximum possible hidden value.
             sol_hi = min(sol_hi, guess-1);
         } else {
             cout << "higher\n";
             cout.flush();
+            // Update the minimum possible hidden value.
             sol_lo = max(sol_lo, guess+1);
         }
     }

--- a/examples/guess/submissions/wrong_answer/guess_modulo.py
+++ b/examples/guess/submissions/wrong_answer/guess_modulo.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+for i in range(1000):
+    print(337*i%1000+1)

--- a/examples/guess/submissions/wrong_answer/guess_modulo.py
+++ b/examples/guess/submissions/wrong_answer/guess_modulo.py
@@ -1,3 +1,25 @@
 #!/usr/bin/env python3
-for i in range(1000):
-    print(337*i%1000+1)
+
+import sys
+
+# This submission exposes a bug in an older version of the output validator
+# where the valid range of possible submissions becomes empty because the range
+# of possible values was updated incorrectly.
+# The expected verdict is WA, but with the bug present, it would give RTE.
+
+min_hidden = 1
+max_hidden = 1000
+
+for guess in [400, 700, 1, 600]:
+    print(guess)
+    ans = input()
+    if ans == 'correct':
+        break
+    elif ans == 'lower':
+        max_hidden = min(max_hidden, guess-1)
+    elif ans == 'higher':
+        min_hidden = max(min_hidden, guess-1)
+    else:
+        assert False
+
+    assert min_hidden <= max_hidden


### PR DESCRIPTION
Currently it's possible to have the following interaction with the adaptive interactor:
```
400
higher
700
higher
1
higher
600
lower
```

We ran into this because we increased the number of allowed queries to `1000` for the BAPC testsession and somebody submitted a program guessing `37*i%1000+1` on the `i`th try.