### PR TITLE
Bump docker to 20.04 LTS and remove Python 2 dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 MAINTAINER austrin@kattis.com
 
@@ -14,10 +14,10 @@ RUN apt-get update && \
             libgmp10 \
             libgmpxx4ldbl \
             openjdk-8-jdk \
-            python-minimal \
-            python-pip \
-            python-plastex \
-            python-yaml \
+            python3-minimal \
+            python3-pip \
+            python3-plastex \
+            python3-yaml \
             sudo \
             texlive-fonts-recommended \
             texlive-lang-cyrillic \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN apt-get update && \
             tidy \
             vim
 
-RUN pip install git+https://github.com/kattis/problemtools
+RUN pip3 install git+https://github.com/kattis/problemtools

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The dependencies needed to *build/install* problemtools can be installed with:
 
 And the dependencies needed to *run* problemtools can be installed with:
 
-    sudo apt install ghostscript libgmpxx4ldbl python-minimal python-pkg-resources python-plastex python-yaml texlive-fonts-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy
+    sudo apt install ghostscript libgmpxx4ldbl python3-minimal python3-pkg-resources python3-plastex python3-yaml texlive-fonts-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy
 
 ### Fedora
 

--- a/admin/docker/Dockerfile.build
+++ b/admin/docker/Dockerfile.build
@@ -28,11 +28,7 @@ RUN apt update && \
         python3 \
         python3-pytest \
         python3-setuptools \
-        python3-yaml \
-        python \
-        python-pytest \
-        python-setuptools \
-        python-yaml
+        python3-yaml
 
 RUN mkdir -p /usr/local/problemtools_build
 

--- a/admin/docker/Dockerfile.build
+++ b/admin/docker/Dockerfile.build
@@ -5,7 +5,7 @@
 # version of problemtools to be built (default is latest version of
 # develop branch on GitHub)
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="austrin@kattis.com"
 

--- a/admin/docker/Dockerfile.minimal
+++ b/admin/docker/Dockerfile.minimal
@@ -10,7 +10,7 @@
 #    PROBLEMTOOLS_VERSION but this is not checked.)
 
 ARG PROBLEMTOOLS_VERSION=develop
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="austrin@kattis.com"
 

--- a/admin/docker/Dockerfile.minimal
+++ b/admin/docker/Dockerfile.minimal
@@ -20,10 +20,8 @@ RUN apt update && \
     apt install -y \
         ghostscript \
         libgmpxx4ldbl \
-        python-minimal \
-        python-pkg-resources \
-        python-plastex \
-        python-yaml \
+        python3-pkg-resources \
+        python3-plastex \
         python3-minimal \
         python3-yaml \
         texlive-fonts-recommended \

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: kattis-problemtools
 Section: devel
 Priority: optional
 Maintainer: Per Austrin <austrin@kattis.com>
-Build-Depends: debhelper (>= 8.0.0), g++ (>= 4.8), dh-python, python3, python3-setuptools, python3-pytest, python3-yaml, python (>= 2.6.6-3~), python-setuptools, python-pytest, python-yaml, libboost-regex-dev, libgmp-dev, automake, autoconf
+Build-Depends: debhelper (>= 8.0.0), g++ (>= 4.8), dh-python, python3, python3-setuptools, python3-pytest, python3-yaml, python (>= 2.6.6-3~), libboost-regex-dev, libgmp-dev, automake, autoconf
 Standards-Version: 3.9.4
 Homepage: https://github.com/Kattis/problemtools
 
 Package: kattis-problemtools
 Architecture: any
-Depends: ${shlibs:Depends}, ${python:Depends}, ${python3:Depends}, ${misc:Depends}, python-yaml, plastex, python3-plastex, python-pkg-resources, texlive-plain-generic, texlive-fonts-recommended, texlive-latex-extra, texlive-lang-cyrillic, tidy, ghostscript
+Depends: ${shlibs:Depends}, ${python3:Depends}, ${misc:Depends}, python3-yaml, plastex, python3-plastex, python3-pkg-resources, texlive-plain-generic, texlive-fonts-recommended, texlive-latex-extra, texlive-lang-cyrillic, tidy, ghostscript
 Recommends: gcc, g++
 Description: Kattis Problem Tools
  These are tools to manage and verify problem packages in the


### PR DESCRIPTION
Python 2 dependencies prevents installation on current Debian/Ubuntu releases, as these have started to remove Python2. I also bumped the docker images to depend on 20.04 LTS. 