### PR TITLE
Make python3 the default for `.py` submissions

### DIFF
--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -207,18 +207,27 @@ prolog:
     compile: '/usr/bin/swipl -O -q -g main -t halt -o {binary} -c {files}'
     run: '{binary}'
 
+# Python2 with shebang comes before default python3.
+python2_with_shebang:
+    name: 'Python 2'
+    priority: 860
+    files: '*.py *.py2'
+    shebang: '^#!.*python2\b'
+    compile: '/usr/bin/python2 -m py_compile {files}'
+    run: '/usr/bin/python2 "{mainfile}"'
+
 python3:
     name: 'Python 3'
-    priority: 900
-    files: '*.py'
-    shebang: '^#!.*python3\b'
+    priority: 850
+    files: '*.py *.py3'
     compile: '/usr/bin/python3 -m py_compile {files}'
     run: '/usr/bin/python3 "{mainfile}"'
 
+# Python2 without shebang comes after python3.
 python2:
     name: 'Python 2'
-    priority: 850
-    files: '*.py'
+    priority: 840
+    files: '*.py2'
     compile: '/usr/bin/python2 -m py_compile {files}'
     run: '/usr/bin/python2 "{mainfile}"'
 


### PR DESCRIPTION
Closes #177.

As @RagnarGrootKoerkamp mentioned, this is not backwards compatible, but it seems like a sane default to me now that Python 2 has been end-of-life for over a year.