### PR TITLE
Improved logging, fix unicode error, include_dir buildrun

### DIFF
--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -7,15 +7,15 @@ import argparse
 import logging
 import subprocess
 
-import plasTeX.TeX
-import plasTeX.Logging
-
-from .ProblemPlasTeX import ProblemRenderer
-from .ProblemPlasTeX import ProblemsetMacros
-from . import template
-
-
 def convert(problem, options=None):
+    import plasTeX.TeX
+    import plasTeX.Logging
+
+    from .ProblemPlasTeX import ProblemRenderer
+    from .ProblemPlasTeX import ProblemsetMacros
+    from . import template
+
+
     problem = os.path.realpath(problem)
 
     problembase = os.path.splitext(os.path.basename(problem))[0]

--- a/problemtools/run/__init__.py
+++ b/problemtools/run/__init__.py
@@ -102,13 +102,18 @@ def get_program(path, language_config=None, work_dir=None, include_dir=None,
         files = [path]
     else:
         build = os.path.join(path, 'build')
-        if os.path.isfile(build) and os.access(path, os.X_OK):
+        if os.path.isfile(build) and os.access(build, os.X_OK):
             return BuildRun(path, work_dir)
         files = rutil.list_files_recursive(path)
 
     if language_config is not None:
         lang = language_config.detect_language(files)
         if lang is not None:
-            return SourceCode(path, lang,
-                              work_dir=work_dir, include_dir=include_dir)
+            if include_dir is not None:
+                lang_dir = os.path.join(include_dir, lang.lang_id)
+                build = os.path.join(lang_dir, 'build')
+                if os.path.isfile(build) and os.access(build, os.X_OK):
+                    return BuildRun(path, work_dir=work_dir, include_dir=lang_dir)
+
+            return SourceCode(path, lang, work_dir=work_dir, include_dir=include_dir)
     return None

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -8,6 +8,9 @@ import logging
 
 from .errors import ProgramError
 
+log = logging.getLogger(__name__)
+
+
 class Program(object):
     """Abstract base class for programs.
     """
@@ -70,8 +73,8 @@ class Program(object):
 
     @staticmethod
     def __run_wait(argv, infile, outfile, errfile, timelim, memlim):
-        logging.debug('run "%s < %s > %s 2> %s"',
-                      ' '.join(argv), infile, outfile, errfile)
+        log.debug('run "%s < %s > %s 2> %s"',
+                  ' '.join(argv), infile, outfile, errfile)
         pid = os.fork()
         if pid == 0:  # child
             try:
@@ -110,7 +113,7 @@ class Program(object):
                 print(exc)
                 os.kill(os.getpid(), signal.SIGTERM)
             # Unreachable
-            logging.error("Unreachable part of run_wait reached")
+            log.error("Unreachable part of run_wait reached")
             os.kill(os.getpid(), signal.SIGTERM)
         (pid, status, rusage) = os.wait4(pid, 0)
         return status, rusage.ru_utime + rusage.ru_stime

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -12,6 +12,9 @@ from .errors import ProgramError
 from .program import Program
 from . import rutil
 
+log = logging.getLogger(__name__)
+
+
 class SourceCode(Program):
     """Class representing a program provided by source code.
     """
@@ -103,7 +106,7 @@ class SourceCode(Program):
         if not os.path.isfile(compiler) or not os.access(compiler, os.X_OK):
             return (False, '%s does not seem to be installed, expected to find compiler at %s' % (self.language.name, compiler))
 
-        logging.debug('compile command: %s', command)
+        log.debug('compile command: %s', command)
 
         try:
             subprocess.check_output(command, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Hi,

I'm using problemtools as library in a larger script to automate deployment of lectures. In that process I found some things I thought needed fixing. I tried to keep changes small and can also make them a bit more consistent. Depending on your wishes, I might address some more things in the future :-)

Mainly, I introduced a bit more consistent logging and added the possibility of having `build/run` in the include_dir. I used this for some java validators where a common build script lies in an included dir.

Closes #201