### PR TITLE
Edited package names that no longer exist for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The dependencies needed to *build/install* problemtools can be installed with:
 
 And the dependencies needed to *run* problemtools can be installed with:
 
-    sudo apt install ghostscript libgmpxx4ldbl python-minimal python-pkg-resources python-plastex python-yaml texlive-fonts-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy
+    sudo apt install ghostscript libgmpxx4ldbl python3-minimal python-pkg-resources python3-plastex python3-yaml texlive-fonts-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy
 
 ### Fedora
 


### PR DESCRIPTION
Attempts to fix #204

Error on Ubuntu 22.04.1 LTS x86_64 when running `sudo apt install ghostscript libgmpxx4ldbl python-minimal python-pkg-resources python-plastex python-yaml texlive-fonts-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic tidy`:
```
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package python-minimal is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python2-minimal:i386 python2-minimal python-is-python3

Package python-yaml is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package python-plastex is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python3-plastex plastex

E: Package 'python-minimal' has no installation candidate
E: Package 'python-plastex' has no installation candidate
E: Package 'python-yaml' has no installation candidate
```

I resolved the installation errors with the following changes:
```
'python-minimal' -> 'python3-minimal'
'python-plastex' -> 'python3-plastex'
'python-yaml' -> 'python3-yaml'
```