### PR TITLE
Do not grade empty groups

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -497,6 +497,9 @@ class TestCaseGroup(ProblemAspect):
             if not f[:-4] + '.in' in infiles:
                 self.error("No matching input file for answer '%s'" % f)
 
+        if not self.get_subgroups() and not self.get_testcases():
+            self.error('Test case group is empty')
+
         # Check whether a <= b according to a natural sorting where numeric components
         # are compactified, so that e.g. "a" < "a1" < "a2" < "a10" = "a010" < "a10a".
         def natural_sort_le(a, b):

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1320,6 +1320,10 @@ class Graders(ProblemAspect):
         verdict = 'AC'
         score = 0
 
+        if not sub_results:
+            self.info('No results on %s, so no graders ran' % (testcasegroup,))
+            return (verdict, score)
+
         grader_flags = testcasegroup.config['grader_flags'].split()
         self.debug('Grading %d results:\n%s' % (len(sub_results), grader_input))
         self.debug('Grader flags: %s' % grader_flags)

--- a/support/default_grader/default_grader
+++ b/support/default_grader/default_grader
@@ -68,4 +68,4 @@ try:
     score = aggregate_scores(scores)
     print('%s %f' % (verdict, score))
 except:
-    print('JE')
+    print('JE 0')


### PR DESCRIPTION
Fixes #189

This causes verifyproblem to give a verdict of `AC` with score of `0` to any empty group, rather than calling the grader on an empty group. It also changes the way the default_grader reports a judge error (reporting a score as well).

These changes are mostly only useful for use in verifyproblem with the `-d` flag, which can filter out test files so that groups appear empty.