### PR TITLE
Updates for plastex 3.0

### DIFF
--- a/problemtools/ProblemPlasTeX/__init__.py
+++ b/problemtools/ProblemPlasTeX/__init__.py
@@ -28,18 +28,10 @@ class ImageConverter(object):
         self.staticimages = {}
 
         # Filename generator
-        
-        # Python 2 compatibility: the second keyword argument for the Filenames
-        # class changed name from vars to variables in Python 3 version.  When
-        # Python 2 compatibility is dropped, change the following command to
-        # self.newFilename = Filenames(self.config['images'].get('filenames', raw=True),
-        #                              variables={'jobname': document.userdata.get('jobname', '')},
-        #                              extension=self.fileExtension, invalid={})
-        self.newFilename = Filenames(self.config['images'].get('filenames', raw=True),
+        self.newFilename = Filenames(self.config['images'].get('filenames'),
                                      None,
-                                     {'jobname': document.userdata.get('jobname', '')},
+                                     variables={'jobname': document.userdata.get('jobname', '')},
                                      extension=self.fileExtension, invalid={})
-
 
     def close(self):
         return

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -38,7 +38,7 @@ def convert(problem, options=None):
 
         # Setup parser and renderer etc
 
-        tex = plasTeX.TeX.TeX(myfile=texfile)
+        tex = plasTeX.TeX.TeX(file=texfile)
 
         ProblemsetMacros.init(tex)
 

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -38,7 +38,12 @@ def convert(problem, options=None):
 
         # Setup parser and renderer etc
 
-        tex = plasTeX.TeX.TeX(file=texfile)
+        try:
+            # try the new version of plasTeX (in version 3.0, the argument is named "file")
+            tex = plasTeX.TeX.TeX(file=texfile)
+        except:
+            # fall back to the old version of plasTeX (previous versions used "myfile")
+            tex = plasTeX.TeX.TeX(myfile=texfile)
 
         ProblemsetMacros.init(tex)
 
@@ -50,6 +55,8 @@ def convert(problem, options=None):
         tex.ownerDocument.config['images']['enabled'] = False
         tex.ownerDocument.config['images']['imager'] = 'none'
         tex.ownerDocument.config['images']['base-url'] = imgbasedir
+        # tell plasTeX where to search for problemtools' built-in packages
+        tex.ownerDocument.config['general']['packages-dirs'] = [os.path.join(os.path.dirname(__file__), 'ProblemPlasTeX')]
 
         renderer = ProblemRenderer()
 

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -38,12 +38,9 @@ def convert(problem, options=None):
 
         # Setup parser and renderer etc
 
-        try:
-            # try the new version of plasTeX (in version 3.0, the argument is named "file")
-            tex = plasTeX.TeX.TeX(file=texfile)
-        except:
-            # fall back to the old version of plasTeX (previous versions used "myfile")
-            tex = plasTeX.TeX.TeX(myfile=texfile)
+        # plasTeX version 3 changed the name of this argument
+        argname = 'myfile' if float(plasTeX.__version__) < 3 else 'file'
+        tex = plasTeX.TeX.TeX(**{argname: texfile})
 
         ProblemsetMacros.init(tex)
 

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(name='problemtools',
       include_package_data=True,
       install_requires=[
           'PyYAML',
-          'plasTeX>=2.0;python_version>="3"'
+          'plasTeX>=3.0;python_version>="3"'
       ],
 #      Temporarily disabled, see setup.cfg
 #      For now tests can be run manually with pytest


### PR DESCRIPTION
Fixes #214 

I have done a bit of testing and this seems to work. This tries to maintain backwards compatibility with the old plasTeX 2.1 while supporting the newer plasTeX 3.0.

As of this writing, the debian package `python3-plastex` gives the old version of plasTeX (2.1), so to test this with the new plasTeX, you should install via pip:
```
python3 -m pip install plastex==3.0
```
and then running bin/problem2html.sh (or however you choose to run it, e.g. via an installed debian package). If you want to test it with the debian package, I had to install it with `dpkg --force-all -i kattis_problemtools*.deb` to install it without the  `python3-plastex` dependency already installed.