### PR TITLE
Handle plastex version diffs by try-catch instead of checking __version__

### DIFF
--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -38,9 +38,13 @@ def convert(problem, options=None):
 
         # Setup parser and renderer etc
 
-        # plasTeX version 3 changed the name of this argument
-        argname = 'myfile' if float(plasTeX.__version__) < 3 else 'file'
-        tex = plasTeX.TeX.TeX(**{argname: texfile})
+        # plasTeX version 3 changed the name of this argument (and guarding against this
+        # by checking plasTeX.__version__ fails on plastex v3.0 which failed to update
+        # __version__)
+        try:
+            tex = plasTeX.TeX.TeX(myfile=texfile)
+        except Exception:
+            tex = plasTeX.TeX.TeX(file=texfile)
 
         ProblemsetMacros.init(tex)
 


### PR DESCRIPTION
Fixes #219. Plastex has gone 2 months now without a new release, and this is actively hurting people using problemtools. Urging plastex to make a new release won't help fully either, because some people will still be stuck on the old plastex version, and it's not immediately clear that you need to `python3 -m pip install --upgrade plastex`.