### PR TITLE
Allow negative scores as grader output

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1297,7 +1297,7 @@ class Graders(ProblemAspect):
             graders = self._graders
 
         grader_input = ''.join(['%s %s\n' % (r.verdict, 0 if r.score is None else r.score) for r in sub_results])
-        grader_output_re = r'^((AC)|(WA)|(TLE)|(RTE)|(JE))\s+[0-9.]+\s*$'
+        grader_output_re = r'^((AC)|(WA)|(TLE)|(RTE)|(JE))\s+-?[0-9.]+\s*$'
         verdict = 'AC'
         score = 0
 


### PR DESCRIPTION
The spec doesn't disallow this: in fact, it mentions -inf as a default lower bound on scores.

I hit upon this by accident, with a buggy output validator -- the negative score was unintended, but problemtools hid the bug from me by claiming an invalid format error with no further output.