### PR TITLE
Fix adding to PYTHONPATH

### DIFF
--- a/bin/problem2html.sh
+++ b/bin/problem2html.sh
@@ -6,5 +6,5 @@
 # not be used.
 
 export PYTHONPATH
-PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
+PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")")${PYTHONPATH:+:}$PYTHONPATH"
 exec python3 -m problemtools.problem2html "$@"

--- a/bin/problem2pdf.sh
+++ b/bin/problem2pdf.sh
@@ -6,5 +6,5 @@
 # not be used.
 
 export PYTHONPATH
-PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
+PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")")${PYTHONPATH:+:}$PYTHONPATH"
 exec python3 -m problemtools.problem2pdf "$@"

--- a/bin/verifyproblem.sh
+++ b/bin/verifyproblem.sh
@@ -6,5 +6,5 @@
 # not be used.
 
 export PYTHONPATH
-PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")"):$PYTHONPATH"
+PYTHONPATH="$(dirname "$(dirname "$(readlink -f "$0")")")${PYTHONPATH:+:}$PYTHONPATH"
 exec python3 -m problemtools.verifyproblem "$@"


### PR DESCRIPTION
Setting PYTHONPATH=newdir:$PYTHONPATH causes an empty component to appear in $PYTHONPATH if it was originally unset. This empty component gets treated the same as ., and this may cause erratic behavior.

(In the case when I encountered this it was because the PYTHONPATH env var leaked into a Python submission, causing it to perform an incorrect import.)