### PR TITLE
Remove unused variable in default validator

### DIFF
--- a/support/default_validator/default_validator.cc
+++ b/support/default_validator/default_validator.cc
@@ -110,7 +110,6 @@ int main(int argc, char **argv) {
 	judgeans_line = stdin_line = 1;
    
 	std::string judge, team;
-	char trash[20];
 	while (true) {
 		// Space!  Can't live with it, can't live without it...
 		while (isspace(judgeans.peek())) {


### PR DESCRIPTION
This is really minor, just something I noticed by chance