### PR TITLE
Fix BuildRun language crashing verifyproblem

### DIFF
--- a/problemtools/run/buildrun.py
+++ b/problemtools/run/buildrun.py
@@ -65,7 +65,7 @@ class BuildRun(Program):
         run = os.path.join(self.path, 'run')
 
         if status:
-            logging.debug('Build script failed (status %d) when compiling %s\n        Command used:\n%s', status, self.name, command)
+            logging.debug('Build script failed (status %d) when compiling %s\n', status, self.name)
             self._compile_result = (False, 'build script failed with exit code %d' % (status))
         elif not os.path.isfile(run) or not os.access(run, os.X_OK):
             self._compile_result = (False, 'build script did not produce an executable called "run"')

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1396,7 +1396,7 @@ class OutputValidators(ProblemAspect):
         recommended_output_validator_languages = {'c', 'cpp', 'python3'}
 
         for v in self._validators:
-            if v.language.lang_id not in recommended_output_validator_languages:
+            if not isinstance(v, run.BuildRun) and v.language.lang_id not in recommended_output_validator_languages:
                 self.warning('output validator language %s is not recommended' % v.language.name)
 
         if self._problem.config.get('validation') == 'default' and self._validators:


### PR DESCRIPTION
`verifyproblem` would crash because BuildRun objects do not have `language` defined.
Fixed that and also a NameError when the build script fails, some reference to a variable that is a relic of an older version that wasn't updated when the variable was removed.