### PR TITLE
Cleanup `problem2{pdf,html}` and use f-strings in `verifyproblem`

### DIFF
--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -31,7 +31,7 @@ def convert(problem, options=None):
 
     texfile = problem
     # Set up template if necessary
-    with template.Template(problem, language=options.language, title=options.title) as templ:
+    with template.Template(problem, language=options.language) as templ:
         texfile = open(templ.get_file_name(), 'r')
 
         origcwd = os.getcwd()
@@ -128,9 +128,6 @@ class ConvertOptions:
          "output file name", 'index.html'],
         ['language', 'store', '-l', '--language',
          'choose alternate language (2-letter code)', None],
-        ['title', 'store', '-T', '--title',
-         'set title (only used when there is no pre-existing template and -h not set)',
-         'Problem Name'],
         ['loglevel', 'store', '-L', '--log-level',
          'set log level (debug, info, warning, error, critical)', 'warning'],
         ['quiet', 'store_true', '-q', '--quiet',

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -127,7 +127,7 @@ class ConvertOptions:
         ['destfile', 'store', '-f', '--dest-file',
          "output file name", 'index.html'],
         ['language', 'store', '-l', '--language',
-         'choose alternate language (2-letter code)', ''],
+         'choose alternate language (2-letter code)', None],
         ['title', 'store', '-T', '--title',
          'set title (only used when there is no pre-existing template and -h not set)',
          'Problem Name'],

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -59,7 +59,7 @@ class ConvertOptions:
          'set title (only used when there is no pre-existing template and -h not set)',
          'Problem Name'],
         ['language', 'store', '-l', '--language',
-         'choose alternate language (2-letter code)', ''],
+         'choose alternate language (2-letter code)', None],
         ['nopdf', 'store_true', '-n', '--no-pdf',
          'run pdflatex in -draftmode', False],
         ]

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -18,8 +18,7 @@ def convert(problem, options=None):
 
     texfile = problem
     # Set up template if necessary
-    with template.Template(problem, language=options.language,
-                           title=options.title) as templ:
+    with template.Template(problem, language=options.language) as templ:
         texfile = templ.get_file_name()
 
         origcwd = os.getcwd()
@@ -55,9 +54,6 @@ class ConvertOptions:
          "output file name", '${problem}.pdf'],
         ['quiet', 'store_true', '-q', '--quiet',
          "quiet", False],
-        ['title', 'store', '-T', '--title',
-         'set title (only used when there is no pre-existing template and -h not set)',
-         'Problem Name'],
         ['language', 'store', '-l', '--language',
          'choose alternate language (2-letter code)', None],
         ['nopdf', 'store_true', '-n', '--no-pdf',

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -14,7 +14,7 @@ def detect_version(problemdir, problemtex):
 
 
 class Template:
-    def __init__(self, problemdir, language='',
+    def __init__(self, problemdir, language=None,
                  title='Problem Title', force_copy_cls=False):
         if not os.path.isdir(problemdir):
             raise Exception('%s is not a directory' % problemdir)
@@ -34,9 +34,9 @@ class Template:
         dotlang = ''
         # If language unspec., use first available one (will be
         # problem.tex if exists)
-        if language == '':
+        if language is None:
             language = langs[0]
-        if language != '':
+        else:
             if len(language) != 2 or not language.isalpha():
                 raise Exception('Invalid language code "%s"' % language)
             if language not in langs:

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -35,7 +35,7 @@ class Template:
         # problem.tex if exists)
         if language is None:
             language = langs[0]
-        else:
+        if language != '':
             if len(language) != 2 or not language.isalpha():
                 raise Exception('Invalid language code "%s"' % language)
             if language not in langs:

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -14,8 +14,7 @@ def detect_version(problemdir, problemtex):
 
 
 class Template:
-    def __init__(self, problemdir, language=None,
-                 title='Problem Title', force_copy_cls=False):
+    def __init__(self, problemdir, language=None, force_copy_cls=False):
         if not os.path.isdir(problemdir):
             raise Exception('%s is not a directory' % problemdir)
 

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -105,7 +105,7 @@ class Template:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
-        if self.problemset_cls is not None and self.copy_cls and  os.path.isfile(self.problemset_cls):
+        if self.problemset_cls is not None and self.copy_cls and os.path.isfile(self.problemset_cls):
             os.remove(self.problemset_cls)
         if self.filename is not None:
             for f in glob.glob(os.path.splitext(self.filename)[0] + '.*'):

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -93,7 +93,7 @@ class Template:
         for line in templin:
             try:
                 templout.write(line % data)
-            except:
+            except KeyError:
                 # This is a bit ugly I guess
                 for sample in self.samples:
                     data['sample'] = sample

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -48,7 +48,7 @@ class Template:
 
         if not os.path.isfile(problemtex):
             raise Exception('Unable to find problem statement, was looking for "%s"' % problemtex)
-        
+
         self.templatefile = 'template.tex'
         self.clsfile = 'problemset.cls'
         timelim = 1  # Legacy for compatibility with v0.1

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -133,8 +133,8 @@ class ProblemAspect:
 class TestCase(ProblemAspect):
     def __init__(self, problem, base, testcasegroup):
         self._base = base
-        self.infile = base + '.in'
-        self.ansfile = base + '.ans'
+        self.infile = f'{base}.in'
+        self.ansfile = f'{base}.ans'
         self._problem = problem
         self.testcasegroup = testcasegroup
         self.reuse_result_from = None
@@ -181,7 +181,7 @@ class TestCase(ProblemAspect):
         return self._check_res
 
     def __str__(self):
-        return 'test case ' + self.strip_path_prefix(self._base)
+        return f'test case {self.strip_path_prefix(self._base)}'
 
     def matches_filter(self, filter_re):
         return filter_re.search(self.strip_path_prefix(self._base)) is not None
@@ -202,7 +202,7 @@ class TestCase(ProblemAspect):
         if not in_target.endswith('.in'):
             self.error(f"Symbolic link does not point to a .in file for input '{nicepath}'")
             return False
-        if ans_target != in_target[:-3] + '.ans':
+        if ans_target != f'{in_target[:-3]}.ans':
             self.error(f"Symbolic link '{nicepath}' must have a corresponding link for answer file")
             return False
         if self.reuse_result_from is None:
@@ -353,7 +353,7 @@ class TestCaseGroup(ProblemAspect):
                     self._items.append(TestCaseGroup(problem, f, self))
                 else:
                     base, ext = os.path.splitext(f)
-                    if ext == '.ans' and os.path.isfile(base + '.in'):
+                    if ext == '.ans' and os.path.isfile(f'{base}.in'):
                         self._items.append(TestCase(problem, base, self))
 
         if not parent:
@@ -361,7 +361,7 @@ class TestCaseGroup(ProblemAspect):
 
 
     def __str__(self):
-        return 'test case group ' + os.path.relpath(self._datadir, os.path.join(self._problem.probdir))
+        return f'test case group {os.path.relpath(self._datadir, os.path.join(self._problem.probdir))}'
 
     def set_symlinks(self):
         for sub in self._items:
@@ -489,11 +489,11 @@ class TestCaseGroup(ProblemAspect):
 
         for f in infiles:
             if os.path.isdir(f): continue
-            if not f[:-3] + '.ans' in ansfiles:
+            if not f'{f[:-3]}.ans' in ansfiles:
                 self.error(f"No matching answer file for input '{f}'")
         for f in ansfiles:
             if os.path.isdir(f): continue
-            if not f[:-4] + '.in' in infiles:
+            if not f'{f[:-4]}.in' in infiles:
                 self.error(f"No matching input file for answer '{f}'")
 
         if not self.get_subgroups() and not self.get_testcases():
@@ -720,7 +720,7 @@ class ProblemConfig(ProblemAspect):
             self.warning("License is 'unknown'")
 
         if self._data['grading']['show_test_data_groups'] not in [True, False]:
-            self.error("Invalid value for grading.show_test_data_groups: " + self._data['grading']['show_test_data_groups'])
+            self.error(f"Invalid value for grading.show_test_data_groups: {self._data['grading']['show_test_data_groups']}")
         elif self._data['grading']['show_test_data_groups'] and self._data['type'] == 'pass-fail':
             self.error("Showing test data groups is only supported for scoring problems, this is a pass-fail problem")
         if self._data['type'] != 'pass-fail' and self._problem.testdata.has_custom_groups() and 'show_test_data_groups' not in self._origdata.get('grading', {}):
@@ -1863,7 +1863,7 @@ def initialize_logging(args):
     fmt = "%(levelname)s %(message)s"
     logging.basicConfig(stream=sys.stdout,
                         format=fmt,
-                        level=eval("logging." + args.log_level.upper()))
+                        level=eval(f"logging.{args.log_level.upper()}"))
 
 
 def main():
@@ -1873,7 +1873,7 @@ def main():
 
     total_errors = 0
     for problemdir in args.problemdir:
-        print('Loading problem ' + os.path.basename(os.path.realpath(problemdir)))
+        print(f'Loading problem {os.path.basename(os.path.realpath(problemdir))}')
         with Problem(problemdir) as prob:
             [errors, warnings] = prob.check(args)
             p = lambda x: '' if x == 1 else 's'

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -482,7 +482,7 @@ class TestCaseGroup(ProblemAspect):
                         hashes[filehash].append(os.path.relpath(filepath, self._problem.probdir))
             for _, files in hashes.items():
                 if len(files) > 1:
-                    self.warning(f"Identical input files: '{str(filed)}'")
+                    self.warning(f"Identical input files: '{str(files)}'")
 
         infiles = glob.glob(os.path.join(self._datadir, '*.in'))
         ansfiles = glob.glob(os.path.join(self._datadir, '*.ans'))


### PR DESCRIPTION
For `problem2{pdf,html}`:
- Changes the default value for `--language` to `None` instead of `''`, and changes code expecting to see `''`. This is partially to improve the `--help` message, which used to read `--language [...] (default: )`. It now reads `(default: None)`
- Removes the option `--title`, as this was never used.

For `verifyproblem`:
- Replaces uses of the `%` operator with f-strings.