### PR TITLE
Fix not showing WA test case verifyproblem.py

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -68,7 +68,7 @@ class SubmissionResult:
 
         if self.reason is not None:
             details.append(self.reason)
-        if self.verdict != 'AC' and self.testcase is not None:
+        if self.testcase is not None:
             details.append(f'test case: {self.testcase}')
         if self.runtime != -1:
             details.append(f'CPU: {self.runtime:.2f}s @ {self.runtime_testcase}')


### PR DESCRIPTION
Edited line 71 in verifyproblem.py. Now verifyproblem will also show what test case it is failing on, and not only the test case that took the longest time to run.

Fixes #247