### PR TITLE
Fix missed init, add test case

### DIFF
--- a/problemtools/tests/test_verify_hello.py
+++ b/problemtools/tests/test_verify_hello.py
@@ -1,0 +1,17 @@
+import pathlib
+import problemtools.verifyproblem as verify
+
+
+def test_load_hello():
+    directory = pathlib.Path(__file__).parent.parent.parent / "examples" / "hello"
+    string = str(directory.resolve())
+
+    args = verify.argparser().parse_args([string])
+    verify.initialize_logging(args)
+
+    with verify.Problem(string) as p:
+        assert p.shortname == "hello"
+        # pytest and fork don't go along very well, so just run aspects that work without run
+        assert p.config.check(args)
+        assert p.attachments.check(args)
+        assert p.generators.check(args)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -136,6 +136,10 @@ class ProblemAspect:
     def debug(self, msg: str, *args) -> None:
         self.log.debug(msg, *args)
 
+    def msg(self, msg):
+        # TODO Should this be silent?
+        print(msg)
+
     def check_basename(self, path: str) -> None:
         basename = os.path.basename(path)
         if not self.basename_regex.match(basename):
@@ -806,6 +810,7 @@ class Generators(ProblemAspect):
     _VISUALIZER_EXTENSIONS = ['png', 'jpg', 'jpeg', 'svg', 'interaction', 'desc', 'hint']
 
     def __init__(self, problem: Problem):
+        super().__init__(f"{problem.shortname}.generators")
         self.debug('  Loading generators')
         self._problem = problem
         self.configfile = os.path.join(problem.probdir, 'generators', 'generators.yaml')


### PR DESCRIPTION
Hi,

I saw I missed one `super().__init__`, sorry! It is fixed now and I added a (shallow) test to check that initialization works.

This doesn't execute a full verifyproblem call (which I should have done before committing!) since pytest and os.fork apparently don't get along very well.

(Should `program.py` be migrated to a subprocess call instead? Setting limits can be done be done with `preexec_fn`)