### PR TITLE
Explicitly set language versions for Java and Kotlin in languages.yaml

### DIFF
--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -147,7 +147,7 @@ java:
     name: 'Java'
     priority: 800
     files: '*.java'
-    compile: '/usr/bin/javac -encoding UTF-8 -sourcepath {path} -d {path} {files}'
+    compile: '/usr/bin/javac -source 11 -encoding UTF-8 -sourcepath {path} -d {path} {files}'
     run: '/usr/bin/java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xss64m -Xms{memlim}m -Xmx{memlim}m -cp {path} {mainclass}'
 
 javascript:
@@ -161,7 +161,7 @@ kotlin:
     name: 'Kotlin'
     priority: 250
     files: '*.kt'
-    compile: '/usr/bin/kotlinc -d {path}/ -- {files}'
+    compile: '/usr/bin/kotlinc -language-version 1.3 -d {path}/ -- {files}'
     run: '/usr/bin/kotlin -Dfile.encoding=UTF-8 -J-XX:+UseSerialGC -J-Xss64m -J-Xms{memlim}m -J-Xmx{memlim}m -cp {path}/ {Mainclass}Kt'
 
 lisp:


### PR DESCRIPTION
Explicitly setting the language version in the compiler options makes it easier to locally debug compile errors when running `verifyproblem` outside Docker. Note that the Kotlin version `1.3` will need to be upgraded to `1.8` soon (see #246), but @ghamerly told me that `1.3` is currently what's still used for installing the problems on Kattis.

It would be nice to also have something similar for Python, but `python` does not have a flag for setting the language version. This would require to explicitly refer to `/usr/bin/python3.8`, but that means I'd need to explicitly install Python 3.8 next to 3.11 on my system, which I'd rather avoid :stuck_out_tongue: 