### PR TITLE
Replace Travis CI with Github actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,43 @@
+# This workflow will install Python dependencies, run tests and lint
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python tests
+
+on:
+  push:
+    branches: [ "master", "develop" ]
+  pull_request:
+    branches: [ "master", "develop" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["pypy3.10", "3.10"] # Arbitrary pick of one pypy and one Cpython version
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        # Exclude examples as there is some python2 code there
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude examples/
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude examples/
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: python
-python:
-  - 3.7
-
-script: py.test

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Kattis Problem Tools
 
 master:
-[![Master Build Status](https://travis-ci.org/Kattis/problemtools.svg?branch=master)](https://travis-ci.org/Kattis/problemtools).
+![Master Build Status](https://github.com/kattis/problemtools/actions/workflows/python-app.yml/badge.svg?branch=master)
 develop:
-[![Develop Build Status](https://travis-ci.org/Kattis/problemtools.svg?branch=develop)](https://travis-ci.org/Kattis/problemtools)
+![Develop Build Status](https://github.com/kattis/problemtools/actions/workflows/python-app.yml/badge.svg?branch=develop)
 
 These are tools to manage problem packages using the Kattis problem package
 format.


### PR DESCRIPTION
Our travis CI has been broken for quite a while. This PR adds a github action to replace travis.

The action is basically github's template. It will use flake8 to fail on syntax errors and generate a large number of warnings/complaints in the log. It also runs our pytests, and fails on any errors there.