### PR TITLE
Add -j flag for multi-threaded validation

### DIFF
--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -110,7 +110,7 @@ def convert(options: argparse.Namespace) -> None:
         os.chdir(origcwd)
 
 
-def get_parser() -> argparse.Namespace:
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('-b', '--body-only', dest='bodyonly', action='store_true', help='only generate HTML body, no HTML headers', default=False)

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -43,7 +43,7 @@ def convert(options: argparse.Namespace) -> bool:
 
     return status == 0
 
-def get_parser() -> argparse.Namespace:
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('-o', '--output', dest='destfile', help="output file name", default='${problem}.pdf')

--- a/problemtools/run/__init__.py
+++ b/problemtools/run/__init__.py
@@ -16,7 +16,7 @@ from . import rutil
 
 
 def find_programs(path, pattern='.*', language_config=None, work_dir=None,
-                  include_dir=None, allow_validation_script=False):
+                  include_dir=None, allow_validation_script=False) -> list[Program]:
     """Find all programs in a directory.
 
     Args:
@@ -62,7 +62,7 @@ def find_programs(path, pattern='.*', language_config=None, work_dir=None,
 
 
 def get_program(path, language_config=None, work_dir=None, include_dir=None,
-                allow_validation_script=False):
+                allow_validation_script=False) -> Program|None:
     """Get a Program object for a program
 
     Args:

--- a/problemtools/run/checktestdata.py
+++ b/problemtools/run/checktestdata.py
@@ -22,27 +22,23 @@ class Checktestdata(Executable):
         if Checktestdata._CTD_PATH is None:
             raise ProgramError(
                 'Could not locate the Checktestdata program to run %s' % path)
-        super(Checktestdata, self).__init__(Checktestdata._CTD_PATH,
-                                            args=[path])
+        super().__init__(Checktestdata._CTD_PATH, args=[path])
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation"""
         return '%s' % (self.args[0])
 
 
-    _compile_result = None
-    def compile(self):
+    def do_compile(self) -> tuple[bool, str|None]:
         """Syntax-check the Checktestdata script
 
         Returns:
             (False, None) if the Checktestdata script has syntax errors and
             (True, None) otherwise
         """
-        if self._compile_result is None:
-            (status, _) = super(Checktestdata, self).run()
-            self._compile_result = ((os.WIFEXITED(status) and os.WEXITSTATUS(status) in [0, 1]), None)
-        return self._compile_result
+        (status, _) = super().run()
+        return ((os.WIFEXITED(status) and os.WEXITSTATUS(status) in [0, 1]), None)
 
 
     def run(self, infile='/dev/null', outfile='/dev/null',

--- a/problemtools/run/executable.py
+++ b/problemtools/run/executable.py
@@ -17,6 +17,8 @@ class Executable(Program):
             args: list of additional command line arguments that
                 should be passed to the program every time it is executed.
         """
+        super().__init__()
+
         if not os.path.isfile(path) or not os.access(path, os.X_OK):
             raise ProgramError('%s is not an executable program' % path)
         self.path = path
@@ -25,11 +27,6 @@ class Executable(Program):
     def __str__(self):
         """String representation"""
         return '%s' % (self.path)
-
-    def compile(self):
-        """Dummy implementation of the compile method -- nothing to check!
-        """
-        return (True, None)
 
     def get_runcmd(self, cwd=None, memlim=None):
         """Command to run the program.

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -39,6 +39,7 @@ class SourceCode(Program):
                 then the files in include_dir/<foo>/ will be copied
                 into the work_dir along with the source file(s).
         """
+        super().__init__()
 
         if path[-1] == '/':
             path = path[:-1]
@@ -80,24 +81,18 @@ class SourceCode(Program):
         self.binary = os.path.join(self.path, 'run')
 
 
-    def code_size(self):
+    def code_size(self) -> int:
         return sum(os.path.getsize(x) for x in self.src)
 
 
-    _compile_result = None
-
-    def compile(self):
+    def do_compile(self) -> tuple[bool, str|None]:
         """Compile the source code.
 
         Returns tuple:
             (True, None) if compilation succeeded
             (False, errmsg) otherwise
         """
-        if self._compile_result is not None:
-            return self._compile_result
-
         if self.language.compile is None:
-            self._compile_result = (True, None)
             return (True, None)
 
         command = self.get_compilecmd()
@@ -110,14 +105,12 @@ class SourceCode(Program):
 
         try:
             subprocess.check_output(command, stderr=subprocess.STDOUT)
-            self._compile_result = (True, None)
+            return (True, None)
         except subprocess.CalledProcessError as err:
-            self._compile_result = (False, err.output.decode('utf8', 'replace'))
-
-        return self._compile_result
+            return (False, err.output.decode('utf8', 'replace'))
 
 
-    def get_compilecmd(self):
+    def get_compilecmd(self) -> list[str]:
         return shlex.split(self.language.compile.format(**self.__get_substitution()))
 
 
@@ -140,12 +133,12 @@ class SourceCode(Program):
         return shlex.split(self.language.run.format(**subs))
 
 
-    def should_skip_memory_rlimit(self):
+    def should_skip_memory_rlimit(self) -> bool:
         """Ugly hack (see program.py for details)."""
         return self.language.name in ['Java', 'Scala', 'Kotlin', 'Common Lisp']
 
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation"""
         return '%s (%s)' % (self.name, self.language.name)
 

--- a/problemtools/run/viva.py
+++ b/problemtools/run/viva.py
@@ -22,8 +22,7 @@ class Viva(Executable):
         if Viva._VIVA_PATH is None:
             raise ProgramError(
                 'Could not locate the VIVA program to run %s' % path)
-        super(Viva, self).__init__(Viva._VIVA_PATH,
-                                   args=[path])
+        super().__init__(Viva._VIVA_PATH, args=[path])
 
 
     def __str__(self):
@@ -31,17 +30,14 @@ class Viva(Executable):
         return '%s' % (self.args[0])
 
 
-    _compile_result = None
-    def compile(self):
+    def do_compile(self) -> tuple[bool, str|None]:
         """Syntax-check the VIVA script
 
         Returns:
             (False, None) if the VIVA script has syntax errors and (True, None) otherwise
         """
-        if self._compile_result is None:
-            (status, _) = super(Viva, self).run()
-            self._compile_result = ((os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0), None)
-        return self._compile_result
+        (status, _) = super().run()
+        return ((os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0), None)
 
 
     def run(self, infile='/dev/null', outfile='/dev/null',


### PR DESCRIPTION
Only parallelizes test case execution and submission compilation at the moment; input validation could be added with a bit of additional work, but it felt less important to me since it takes almost no time with validators written in C++ as we usually have it.

mypy is happy with the refactoring and I've done some lightweight testing, but it's possible that there's some breakage along less happy paths, though probably restricted to -j.