### PR TITLE
Remove non-standard `judgeerror.txt` from example problems

### DIFF
--- a/examples/different/output_validators/different_validator/validate.h
+++ b/examples/different/output_validators/different_validator/validate.h
@@ -56,7 +56,6 @@ const int EXITCODE_AC = 42;
 const int EXITCODE_WA = 43;
 const std::string FILENAME_AUTHOR_MESSAGE = "teammessage.txt";
 const std::string FILENAME_JUDGE_MESSAGE = "judgemessage.txt";
-const std::string FILENAME_JUDGE_ERROR = "judgeerror.txt";
 const std::string FILENAME_SCORE = "score.txt";
 
 #define USAGE "%s: judge_in judge_ans feedback_dir < author_out\n"
@@ -107,7 +106,7 @@ void wrong_answer(const std::string &msg, ...) {
 void judge_error(const std::string &msg, ...) {
     va_list pvar;
     va_start(pvar, msg);
-    vreport_feedback(FILENAME_JUDGE_ERROR, msg, pvar);
+    vreport_feedback(FILENAME_JUDGE_MESSAGE, msg, pvar);
     assert(0);
 }
 

--- a/examples/guess/output_validators/guess_validator/validate.h
+++ b/examples/guess/output_validators/guess_validator/validate.h
@@ -56,7 +56,6 @@ const int EXITCODE_AC = 42;
 const int EXITCODE_WA = 43;
 const std::string FILENAME_AUTHOR_MESSAGE = "teammessage.txt";
 const std::string FILENAME_JUDGE_MESSAGE = "judgemessage.txt";
-const std::string FILENAME_JUDGE_ERROR = "judgeerror.txt";
 const std::string FILENAME_SCORE = "score.txt";
 
 #define USAGE "%s: judge_in judge_ans feedback_dir < author_out\n"
@@ -107,7 +106,7 @@ void wrong_answer(const std::string &msg, ...) {
 void judge_error(const std::string &msg, ...) {
     va_list pvar;
     va_start(pvar, msg);
-    vreport_feedback(FILENAME_JUDGE_ERROR, msg, pvar);
+    vreport_feedback(FILENAME_JUDGE_MESSAGE, msg, pvar);
     assert(0);
 }
 


### PR DESCRIPTION
Two of the example problems put debug messages in a non-standard file `judgeerror.txt` when encountering a judge error. This PR changes the output validators to output the message to the standardized `judgemessage.txt` instead.