### PR TITLE
Change Rust compilation flags

### DIFF
--- a/examples/hello/submissions/accepted/hello.rs
+++ b/examples/hello/submissions/accepted/hello.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello World!");
+}

--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -245,8 +245,8 @@ rust:
     name: 'Rust'
     priority: 575
     files: '*.rs'
-    compile: '/usr/bin/rustc -o{binary} -O --crate-type bin --edition=2018 {files}'
-    run: '{binary}'
+    compile: '/usr/bin/rustc -C opt-level=3 -C target-cpu=native --crate-type bin --edition 2021 {mainfile} -o {mainfile}.out'
+    run: '{mainfile}.out'
 
 scala:
     name: 'Scala'


### PR DESCRIPTION
This PR has two main aims:
- Make the rust compilation flags more consistent with what Kattis is using by increasing optimization level to 3, allowing target-cpu=native and bumping version to 2021.
- Make it possible to compile multiple files. I'm very new to Rust, so take everything i say with a large grain of salt. As far as i understand, the intended use of rustc seems to be that you only give it the main file, which then imports modules. Thus, because the behavior when handling submissions with multiple files currently is to feed all of them into rustc, it simply gives an error. Changing it to {mainfile} instead of {files} allows you to submit multiple files if you place the main function in the file called main.rs. It also doesn't break  existing submissions with a single file, no matter their name. Note that these are the only ones that can currently compile, so I don't think there are any drawbacks to this change.

Motivation: I want to create a problem with a "judge runner" by using the include folder, like https://open.kattis.com/problems/vectorfunctions. 