### PR TITLE
Update default_validator; add custom error when user output is empty

### DIFF
--- a/support/default_validator/default_validator.cc
+++ b/support/default_validator/default_validator.cc
@@ -146,7 +146,7 @@ int main(int argc, char **argv) {
 					);
 				} else {
 					wrong_answer(
-						"User EOF while judge had more output; user output contained no tokens.\n(Next judge token: %s)",
+						"User EOF while judge had more output; user output contained only whitespace.\n(Next judge token: %s)",
 						judge.c_str()
 					);
 				}


### PR DESCRIPTION
When the user output file is completely empty, add the error message "user output was empty"; when the user output file contains only whitespace, add the error message "user output contained no tokens".

Other changes:
 - Rewrite `if (...) stmt;` as `if (...) { stmt; }`
 - Explicitly assign zero to `judgeans_pos` and `stdin_pos` (line 17). Previously, they were implicitly initialized to zero (since they are global variables).
 - Initialize `judgeans_line` and `stdin_line` to `1` (line 18). Previously, they were set to `1` in `main()`, before the `while (true)` loop.
 - Add some whitespace to be more consistent.