### PR TITLE
Remove deprecated functionality of legacy format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /problemtools.egg-info/
 /support/default_validator/default_validator
 /support/interactive/interactive
+build/


### PR DESCRIPTION
Legacy format had some old stuff that is not supposed to be checked.

- Generators: should not be a part of the old problem format
- Checking (programming) langugages in config: Should not be a part of the old format, although it will be reimplemented again in the new format