### PR TITLE
Fix CI tests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install apt packages (for debbuild)
-      run: sudo apt-get install debhelper dh-python python3-pytest libboost-regex-dev
+      run: sudo apt-get install debhelper dh-python python3-pytest libboost-regex-dev build-essential
       shell: bash
     - name: Install dependencies
       run: |

--- a/problemtools/tests/test_verify_hello.py
+++ b/problemtools/tests/test_verify_hello.py
@@ -14,4 +14,3 @@ def test_load_hello():
         # pytest and fork don't go along very well, so just run aspects that work without run
         assert p.config.check(args)
         assert p.attachments.check(args)
-        assert p.generators.check(args)


### PR DESCRIPTION
Looks like CI has been failing for a bit. I don't see any code changes we've made that should have caused it, so likely this is due to changes upstream (changed images and/or dependencies).

Our builds fail on
```
dpkg-checkbuilddeps: error: Unmet build dependencies: build-essential:native
```
so this PR explicitly `apt-get`s `build-essential` in our github workflow.

As this has been broken for a bit, one of the unit test had gone bad too - it tried to test generators in `verifyproblem`, which no longer exists.