### PR TITLE
Allow verifying statements according to the new problem format

### DIFF
--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -1,7 +1,10 @@
 import os
-
 import yaml
 
+
+"""
+Returns the problem version value of problem.yaml or throws an error if it is unable to read the file.
+"""
 
 def detect_problem_version(path) -> str:
     config_path = os.path.join(path, 'problem.yaml')
@@ -13,9 +16,41 @@ def detect_problem_version(path) -> str:
     return config.get('problem_format_version', 'legacy')
 
 
+"""
+Returns a FormatVersionData object based on the format version found in problem.yaml
+"""
+
+def get_format_version_data_by_dir(path):
+    version = detect_problem_version(path)
+    return get_format_version_data_by_name(version)
+
+
+"""
+Returns a FormatVersionData object based on the format version found in problem.yaml
+"""
+
+def get_format_version_data_by_name(version_name):
+    if version_name == "legacy":
+        return DataLegacy()
+    elif version_name == "2023-07":
+        return Data2023_07()
+    else:
+        raise VersionError(f"Unknown version {version_name}")
+
+
+"""
+A superclass for all the format version-specific variables and information
+"""
 class FormatVersionData:
+    FORMAT_VERSION = ""
     STATEMENT_DIRECTORY = ""
     STATEMENT_EXTENSIONS = []
+
+    def get_format_version(self):
+        if self.FORMAT_VERSION == "":
+            raise NotImplementedError()
+        else:
+            return self.FORMAT_VERSION
 
     def get_statement_directory(self):
         if self.STATEMENT_DIRECTORY == "":
@@ -29,25 +64,17 @@ class FormatVersionData:
         else:
             return self.STATEMENT_EXTENSIONS
 
-    @staticmethod
-    def get_statement_data(path):
-        version = detect_problem_version(path)
-        if version == "legacy":
-            return StatementLegacyData
-        elif version == "2023-07":
-            return Statement2023_07Data
 
-
-class StatementLegacyData(FormatVersionData):
-    EXTENSIONS = ['tex']
-    STATEMENT_DIRECTORY = "problem_statement"
+class DataLegacy(FormatVersionData):
     FORMAT_VERSION = "legacy"
-    
+    STATEMENT_DIRECTORY = "problem_statement"
+    STATEMENT_EXTENSIONS = ['tex']
 
-class Statement2023_07Data(FormatVersionData):
-    EXTENSIONS = ['md', 'tex']
-    DIR_END = "statement"
+
+class Data2023_07(FormatVersionData):
     FORMAT_VERSION = "2023-07"
+    STATEMENT_DIRECTORY = "statement"
+    STATEMENT_EXTENSIONS = ['md', 'tex']
 
 
 class VersionError(Exception):

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -1,0 +1,55 @@
+import os
+
+import yaml
+
+
+def detect_problem_version(path) -> str:
+    config_path = os.path.join(path, 'problem.yaml')
+    try:
+        with open(config_path) as f:
+            config: dict = yaml.safe_load(f) or {}
+    except Exception as e:
+        raise VersionError(f"Error reading problem.yaml: {e}")
+    return config.get('problem_format_version', 'legacy')
+
+
+class FormatVersionData:
+    STATEMENT_DIRECTORY = ""
+    STATEMENT_EXTENSIONS = []
+
+    def get_statement_directory(self):
+        if self.STATEMENT_DIRECTORY == "":
+            raise NotImplementedError()
+        else:
+            return self.STATEMENT_DIRECTORY
+
+    def get_statement_extensions(self):
+        if not self.STATEMENT_EXTENSIONS:
+            raise NotImplementedError()
+        else:
+            return self.STATEMENT_EXTENSIONS
+
+    @staticmethod
+    def get_statement_data(path):
+        version = detect_problem_version(path)
+        if version == "legacy":
+            return StatementLegacyData
+        elif version == "2023-07":
+            return Statement2023_07Data
+
+
+class StatementLegacyData(FormatVersionData):
+    EXTENSIONS = ['tex']
+    STATEMENT_DIRECTORY = "problem_statement"
+    FORMAT_VERSION = "legacy"
+    
+
+class Statement2023_07Data(FormatVersionData):
+    EXTENSIONS = ['md', 'tex']
+    DIR_END = "statement"
+    FORMAT_VERSION = "2023-07"
+
+
+class VersionError(Exception):
+    pass
+

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -18,6 +18,9 @@ FORMAT_DATA = {
     }
 }
 
+VERSION_LEGACY = "legacy"
+VERSION_2023_07 = "2023-07"
+
 
 """
 Returns the problem version value of problem.yaml or throws an error if it is unable to read the file.

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -9,6 +9,12 @@ VERSION_2023_07 = "2023-07"
 
 @dataclass(frozen=True)
 class FormatData:
+    """
+    A class containing data specific to the format version.
+    name: the version name.
+    statement_directory: the directory where the statements should be found.
+    statement_extensions: the allowed extensions for the statements.
+    """
     name: str
     statement_directory: str
     statement_extensions: list[str]
@@ -20,10 +26,16 @@ FORMAT_DATACLASSES = {
 }
 
 
-"""
-Returns the problem version value of problem.yaml or throws an error if it is unable to read the file.
-"""
 def detect_problem_version(path) -> str:
+    """
+    Returns the problem version value of problem.yaml or throws an error if it is unable to read the file.
+    Args:
+        path: the problem path
+
+    Returns:
+        the version name as a String
+
+    """
     config_path = os.path.join(path, 'problem.yaml')
     try:
         with open(config_path) as f:
@@ -33,22 +45,29 @@ def detect_problem_version(path) -> str:
     return config.get('problem_format_version', VERSION_LEGACY)
 
 
-"""
-Returns a dataclass containing the necessary data for a file format.
-"""
 def get_format_data(path):
-    version = detect_problem_version(path)
-    data = FORMAT_DATACLASSES[version]
-    if not data:
-        raise VersionError(f"No version found with name {version}")
-    else:
-        return data
+    """
+    Gets the dataclass object containing the necessary data for a problem format.
+    Args:
+        path: the problem path
+
+    Returns:
+        the dataclass object containing the necessary data for a problem format
+
+    """
+    return get_format_data_by_name(detect_problem_version(path))
 
 
-"""
-Returns a dataclass containing the necessary data for a file format given the format's name. 
-"""
 def get_format_data_by_name(name):
+    """
+    Gets the dataclass object containing the necessary data for a problem format given the format name.
+    Args:
+        name: the format name
+
+    Returns:
+        the dataclass object containing the necessary data for a problem format
+
+    """
     data = FORMAT_DATACLASSES.get(name)
     if not data:
         raise VersionError(f"No version found with name {name}")

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -1,25 +1,23 @@
 import os
 import yaml
+from dataclasses import dataclass
 
-
-"""
-The data specific to any given format version.
-"""
-FORMAT_DATA = {
-    "legacy": {
-        "name": "legacy",
-        "statement_directory": "problem_statement",
-        "statement_extensions": ["tex"]
-    },
-    "2023-07": {
-        "name": "2023-07",
-        "statement_directory": "statement",
-        "statement_extensions": ["md", "tex"],
-    }
-}
 
 VERSION_LEGACY = "legacy"
 VERSION_2023_07 = "2023-07"
+
+
+@dataclass(frozen=True)
+class FormatData:
+    name: str
+    statement_directory: str
+    statement_extensions: list[str]
+
+
+FORMAT_DATACLASSES = {
+    VERSION_LEGACY: FormatData(name=VERSION_LEGACY, statement_directory="problem_statement", statement_extensions=["tex"]),
+    VERSION_2023_07: FormatData(name=VERSION_2023_07, statement_directory="statement", statement_extensions=["md", "tex"])
+}
 
 
 """
@@ -32,15 +30,15 @@ def detect_problem_version(path) -> str:
             config: dict = yaml.safe_load(f) or {}
     except Exception as e:
         raise VersionError(f"Error reading problem.yaml: {e}")
-    return config.get('problem_format_version', 'legacy')
+    return config.get('problem_format_version', VERSION_LEGACY)
 
 
 """
-Returns a dictionary containing the necessary data for a file format.
+Returns a dataclass containing the necessary data for a file format.
 """
 def get_format_data(path):
     version = detect_problem_version(path)
-    data = FORMAT_DATA.get(version)
+    data = FORMAT_DATACLASSES[version]
     if not data:
         raise VersionError(f"No version found with name {version}")
     else:
@@ -48,14 +46,15 @@ def get_format_data(path):
 
 
 """
-Returns a dictionary containing the necessary data for a file format given the format's name. 
+Returns a dataclass containing the necessary data for a file format given the format's name. 
 """
 def get_format_data_by_name(name):
-    data = FORMAT_DATA.get(name)
+    data = FORMAT_DATACLASSES.get(name)
     if not data:
         raise VersionError(f"No version found with name {name}")
     else:
         return data
+
 
 class VersionError(Exception):
     pass

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -3,9 +3,25 @@ import yaml
 
 
 """
+The data specific to any given format version.
+"""
+FORMAT_DATA = {
+    "legacy": {
+        "name": "legacy",
+        "statement_directory": "problem_statement",
+        "statement_extensions": ["tex"]
+    },
+    "2023-07": {
+        "name": "2023-07",
+        "statement_directory": "statement",
+        "statement_extensions": ["md", "tex"],
+    }
+}
+
+
+"""
 Returns the problem version value of problem.yaml or throws an error if it is unable to read the file.
 """
-
 def detect_problem_version(path) -> str:
     config_path = os.path.join(path, 'problem.yaml')
     try:
@@ -17,65 +33,26 @@ def detect_problem_version(path) -> str:
 
 
 """
-Returns a FormatVersionData object based on the format version found in problem.yaml
+Returns a dictionary containing the necessary data for a file format.
 """
-
-def get_format_version_data_by_dir(path):
+def get_format_data(path):
     version = detect_problem_version(path)
-    return get_format_version_data_by_name(version)
-
-
-"""
-Returns a FormatVersionData object based on the format version found in problem.yaml
-"""
-
-def get_format_version_data_by_name(version_name):
-    if version_name == "legacy":
-        return DataLegacy()
-    elif version_name == "2023-07":
-        return Data2023_07()
+    data = FORMAT_DATA.get(version)
+    if not data:
+        raise VersionError(f"No version found with name {version}")
     else:
-        raise VersionError(f"Unknown version {version_name}")
+        return data
 
 
 """
-A superclass for all the format version-specific variables and information
+Returns a dictionary containing the necessary data for a file format given the format's name. 
 """
-class FormatVersionData:
-    FORMAT_VERSION = ""
-    STATEMENT_DIRECTORY = ""
-    STATEMENT_EXTENSIONS = []
-
-    def get_format_version(self):
-        if self.FORMAT_VERSION == "":
-            raise NotImplementedError()
-        else:
-            return self.FORMAT_VERSION
-
-    def get_statement_directory(self):
-        if self.STATEMENT_DIRECTORY == "":
-            raise NotImplementedError()
-        else:
-            return self.STATEMENT_DIRECTORY
-
-    def get_statement_extensions(self):
-        if not self.STATEMENT_EXTENSIONS:
-            raise NotImplementedError()
-        else:
-            return self.STATEMENT_EXTENSIONS
-
-
-class DataLegacy(FormatVersionData):
-    FORMAT_VERSION = "legacy"
-    STATEMENT_DIRECTORY = "problem_statement"
-    STATEMENT_EXTENSIONS = ['tex']
-
-
-class Data2023_07(FormatVersionData):
-    FORMAT_VERSION = "2023-07"
-    STATEMENT_DIRECTORY = "statement"
-    STATEMENT_EXTENSIONS = ['md', 'tex']
-
+def get_format_data_by_name(name):
+    data = FORMAT_DATA.get(name)
+    if not data:
+        raise VersionError(f"No version found with name {name}")
+    else:
+        return data
 
 class VersionError(Exception):
     pass

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -123,6 +123,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-L', '--log-level', dest='loglevel', help='set log level (debug, info, warning, error, critical)', default='warning')
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', help="quiet", default=False)
     parser.add_argument('-i', '--imgbasedir', dest='imgbasedir', default='')
+    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="legacy")
     parser.add_argument('problem', help='the problem to convert')
 
     return parser

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -123,7 +123,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-L', '--log-level', dest='loglevel', help='set log level (debug, info, warning, error, critical)', default='warning')
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', help="quiet", default=False)
     parser.add_argument('-i', '--imgbasedir', dest='imgbasedir', default='')
-    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="legacy")
+    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="automatic")
     parser.add_argument('problem', help='the problem to convert')
 
     return parser

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -123,7 +123,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-L', '--log-level', dest='loglevel', help='set log level (debug, info, warning, error, critical)', default='warning')
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', help="quiet", default=False)
     parser.add_argument('-i', '--imgbasedir', dest='imgbasedir', default='')
-    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="automatic")
+    parser.add_argument('-v', '--format-version', dest='format_version', help='choose format version', default="automatic")
     parser.add_argument('problem', help='the problem to convert')
 
     return parser

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -50,7 +50,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', help="quiet", default=False)
     parser.add_argument('-l', '--language', dest='language', help='choose alternate language (2-letter code)', default=None)
     parser.add_argument('-n', '--no-pdf', dest='nopdf', action='store_true', help='run pdflatex in -draftmode', default=False)
-    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="automatic")
+    parser.add_argument('-v', '--format-version', dest='format_version', help='choose format version', default="automatic")
     parser.add_argument('problem', help='the problem to convert')
 
     return parser

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -50,6 +50,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', help="quiet", default=False)
     parser.add_argument('-l', '--language', dest='language', help='choose alternate language (2-letter code)', default=None)
     parser.add_argument('-n', '--no-pdf', dest='nopdf', action='store_true', help='run pdflatex in -draftmode', default=False)
+    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="legacy")
     parser.add_argument('problem', help='the problem to convert')
 
     return parser

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -50,7 +50,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', help="quiet", default=False)
     parser.add_argument('-l', '--language', dest='language', help='choose alternate language (2-letter code)', default=None)
     parser.add_argument('-n', '--no-pdf', dest='nopdf', action='store_true', help='run pdflatex in -draftmode', default=False)
-    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="legacy")
+    parser.add_argument('-F', '--format-version', dest='format_version', help='choose format version', default="automatic")
     parser.add_argument('problem', help='the problem to convert')
 
     return parser

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -3,7 +3,8 @@ import os.path
 import glob
 import tempfile
 import shutil
-import yaml
+
+from . import formatversion
 
 
 # For backwards compatibility, remove in bright and shiny future.
@@ -23,14 +24,12 @@ class Template:
             problemdir = problemdir[:-1]
 
         if version == "automatic":
-            version = self.detect_problem_version(problemdir)
+            version_data = formatversion.get_format_version_data_by_dir(problemdir)
 
-        if version == "2023-07":
-            statement_directory = "statement"
         else:
-            statement_directory = "problem_statement"
+            version_data = formatversion.get_format_version_data_by_name(version)
 
-        stmtdir = os.path.join(problemdir, statement_directory)
+        stmtdir = os.path.join(problemdir, version_data.get_statement_directory())
 
 
 
@@ -128,11 +127,3 @@ class Template:
         assert os.path.isfile(self.filename)
         return self.filename
 
-    def detect_problem_version(self, path) -> str:
-        config_path = os.path.join(path, 'problem.yaml')
-        try:
-            with open(config_path) as f:
-                config: dict = yaml.safe_load(f) or {}
-        except Exception as e:
-            raise RuntimeError(f"Error reading problem.yaml: {e}")
-        return config.get('problem_format_version', 'legacy')

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -24,15 +24,12 @@ class Template:
             problemdir = problemdir[:-1]
 
         if version == "automatic":
-            version_data = formatversion.get_format_version_data_by_dir(problemdir)
+            version_data = formatversion.get_format_data(problemdir)
 
         else:
-            version_data = formatversion.get_format_version_data_by_name(version)
+            version_data = formatversion.get_format_data_by_name(version)
 
-        stmtdir = os.path.join(problemdir, version_data.get_statement_directory())
-
-
-
+        stmtdir = os.path.join(problemdir, version_data.get('statement_directory'))
         langs = []
         if glob.glob(os.path.join(stmtdir, 'problem.tex')):
             langs.append('')

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -15,14 +15,14 @@ def detect_version(problemdir, problemtex):
 
 
 class Template:
-    def __init__(self, problemdir, language=None, force_copy_cls=False, version="default"):
+    def __init__(self, problemdir, language=None, force_copy_cls=False, version="automatic"):
         if not os.path.isdir(problemdir):
             raise Exception('%s is not a directory' % problemdir)
 
         if problemdir[-1] == '/':
             problemdir = problemdir[:-1]
 
-        if version == "default":
+        if version == "automatic":
             version = self.detect_problem_version(problemdir)
 
         if version == "2023-07":

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -29,7 +29,7 @@ class Template:
         else:
             version_data = formatversion.get_format_data_by_name(version)
 
-        stmtdir = os.path.join(problemdir, version_data.get('statement_directory'))
+        stmtdir = os.path.join(problemdir, version_data.statement_directory)
         langs = []
         if glob.glob(os.path.join(stmtdir, 'problem.tex')):
             langs.append('')

--- a/problemtools/templates/latex/problemset.cls
+++ b/problemtools/templates/latex/problemset.cls
@@ -163,7 +163,12 @@
 %% Problem inclusion
 \newcommand{\includeproblem}[1]{
   \startproblem{#1}
-  \import{#1/problem_statement/}{problem\@problemlanguage.tex}
+\IfFileExists{#1/statement/problem\@problemlanguage.tex}{%
+    \import{#1/statement/}{problem\@problemlanguage.tex}%
+}{%
+    \import{#1/problem_statement/}{problem\@problemlanguage.tex}%
+}
+
 
   %% Automatically include samples 1..9, if enabled
   \ifplastex\else

--- a/problemtools/templates/latex/problemset_0.1.cls
+++ b/problemtools/templates/latex/problemset_0.1.cls
@@ -138,12 +138,7 @@
 %% Problem inclusion
 \newcommand{\includeproblem}[3]{
   \startproblem{#1}{#2}{#3}
-\IfFileExists{#1/statement/problem\@problemlanguage.tex}{%
-    \import{#1/statement/}{problem\@problemlanguage.tex}%
-}{%
-    \import{#1/problem_statement/}{problem\@problemlanguage.tex}%
-}
-
+  \import{#1/problem_statement/}{problem\@problemlanguage.tex}
 }
 
 \newcommand{\startproblem}[3]{

--- a/problemtools/templates/latex/problemset_0.1.cls
+++ b/problemtools/templates/latex/problemset_0.1.cls
@@ -138,7 +138,12 @@
 %% Problem inclusion
 \newcommand{\includeproblem}[3]{
   \startproblem{#1}{#2}{#3}
-  \import{#1/problem_statement/}{problem\@problemlanguage.tex}
+\IfFileExists{#1/statement/problem\@problemlanguage.tex}{%
+    \import{#1/statement/}{problem\@problemlanguage.tex}%
+}{%
+    \import{#1/problem_statement/}{problem\@problemlanguage.tex}%
+}
+
 }
 
 \newcommand{\startproblem}[3]{

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -711,19 +711,20 @@ class TestCaseGroup(ProblemAspect):
 
 
 class ProblemStatement(ProblemPart):
-    FORMAT_DATA = None
+    format_data = None
 
     def setup(self):
-        self.FORMAT_DATA = formatversion.get_format_data(self.problem.probdir)
-        if not self.FORMAT_DATA:
+        self.format_data = formatversion.get_format_data(self.problem.probdir)
+        print(self.format_data.name)
+        if not self.format_data:
             raise NotImplementedError('No version selected.')
         self.debug('  Loading problem statement')
-        self.statement_regex = re.compile(r"problem(\.([a-z]{2,3}|[a-z]{2}-[A-Z]{2}))?\.(%s)$" % ('|'.join(self.FORMAT_DATA.get("statement_extensions"))))
-        dir = os.path.join(self.problem.probdir, self.FORMAT_DATA.get("statement_directory"))
+        self.statement_regex = re.compile(r"problem(\.([a-z]{2,3}|[a-z]{2}-[A-Z]{2}))?\.(%s)$" % ('|'.join(self.format_data.statement_extensions)))
+        dir = os.path.join(self.problem.probdir, self.format_data.statement_directory)
         if os.path.isdir(dir):
             self.statements = [(m.group(0), m.group(2) or '') for file in os.listdir(dir) if (m := re.search(self.statement_regex, file))]
         else:
-            self.error(f"No directory named {self.FORMAT_DATA.get('statement_directory')} found")
+            self.error(f"No directory named {self.format_data.statement_directory} found"
             self.statements = []
 
         return self.get_config()
@@ -734,8 +735,8 @@ class ProblemStatement(ProblemPart):
         self._check_res = True
 
         if not self.statements:
-            allowed_statements = ', '.join(f'problem.{ext}, problem.[a-z][a-z].{ext}' for ext in self.FORMAT_DATA.get("statement_extensions"))
-            self.error(f'No problem statements found (expected file of one of following forms in directory {self.FORMAT_DATA.get("statement_directory")}/: {allowed_statements})')
+            allowed_statements = ', '.join(f'problem.{ext}, problem.[a-z][a-z].{ext}' for ext in self.format_data.statement_extensions)
+            self.error(f'No problem statements found (expected file of one of following forms in directory {self.format_data.statement_directory}/: {allowed_statements})')
 
         langs = [lang or 'en' for _, lang in self.statements]
         for lang, count in collections.Counter(langs).items():
@@ -772,7 +773,7 @@ class ProblemStatement(ProblemPart):
     def get_config(self) -> dict[str, dict[str, str]]:
         ret: dict[str, dict[str, str]] = {'name':{}}
         for filename, lang in self.statements:
-            dir = os.path.join(self.problem.probdir, self.FORMAT_DATA.get("statement_directory"))
+            dir = os.path.join(self.problem.probdir, self.format_data.statement_directory)
             with open(os.path.join(dir, filename)) as f:
                 stmt = f.read()
             hit = re.search(r'\\problemname{(.*)}', stmt, re.MULTILINE)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -20,7 +20,6 @@ import sys
 import copy
 import random
 import traceback
-import formatversion
 
 import argparse
 import shlex
@@ -29,6 +28,7 @@ import yaml
 
 from . import problem2pdf
 from . import problem2html
+from . import formatversion
 
 from . import config
 from . import languages

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -711,11 +711,10 @@ class TestCaseGroup(ProblemAspect):
 
 
 class ProblemStatement(ProblemPart):
-    format_data = None
+    PART_NAME = 'statement'
 
     def setup(self):
         self.format_data = formatversion.get_format_data(self.problem.probdir)
-        print(self.format_data.name)
         if not self.format_data:
             raise NotImplementedError('No version selected.')
         self.debug('  Loading problem statement')
@@ -724,7 +723,7 @@ class ProblemStatement(ProblemPart):
         if os.path.isdir(dir):
             self.statements = [(m.group(0), m.group(2) or '') for file in os.listdir(dir) if (m := re.search(self.statement_regex, file))]
         else:
-            self.error(f"No directory named {self.format_data.statement_directory} found"
+            self.error(f"No directory named {self.format_data.statement_directory} found")
             self.statements = []
 
         return self.get_config()

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -714,6 +714,7 @@ class ProblemStatement(ProblemPart):
     FORMAT_DATA = None
 
     def setup(self):
+        self.FORMAT_DATA = formatversion.get_format_data(self.problem.probdir)
         if not self.FORMAT_DATA:
             raise NotImplementedError('No version selected.')
         self.debug('  Loading problem statement')
@@ -767,10 +768,6 @@ class ProblemStatement(ProblemPart):
 
     def __str__(self) -> str:
         return 'problem statement'
-
-    def __init__(self, problem: Problem):
-        super().__init__(problem)
-        self.FORMAT_DATA = formatversion.get_format_data(self.problem.probdir)
 
     def get_config(self) -> dict[str, dict[str, str]]:
         ret: dict[str, dict[str, str]] = {'name':{}}

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -736,7 +736,7 @@ class ProblemStatement(ProblemPart):
         self._check_res = True
 
         if not self.statements:
-            allowed_statements = ', '.join(f'problem.{ext}, problem.[a-z][a-z].{ext}' for ext in STATEMENT_DATA.get_statement_extensions)
+            allowed_statements = ', '.join(f'problem.{ext}, problem.[a-z][a-z].{ext}' for ext in STATEMENT_DATA.get_statement_extensions())
             self.error(f'No problem statements found (expected file of one of following forms in directory {STATEMENT_DATA.get_statement_directory()}/: {allowed_statements})')
 
         langs = [lang or 'en' for _, lang in self.statements]

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -751,7 +751,6 @@ class ProblemStatement(ProblemPart):
                 options.language = lang
                 options.nopdf = True
                 options.quiet = True
-                options.format_version = self.FORMAT_VERSION
                 if not problem2pdf.convert(options):
                     langparam = f' --language {lang}' if lang != '' else ''
                     self.error(f'Could not compile problem statement for language "{lang}".  Run problem2pdf{langparam} on the problem to diagnose.')


### PR DESCRIPTION
## Overview
* verifyproblem.py now checks the appropriate location for the problem statements based on the version of problem format.
* problem2html.py and problem2pdf.py now both take a flag "-F" which specifies the format used, which defaults to legacy. This flag is added because both files take the problem directory as an argument and therefore need to know where to expect the statements.
* Also allows the constructor for template.py to specify a version for the same reasons.
* The cls templates now also allow for using either version.