### PR TITLE
Add back warning/error logging

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -2121,8 +2121,7 @@ def argparser() -> argparse.ArgumentParser:
 def initialize_logging(args: argparse.Namespace) -> None:
     ProblemAspect.max_additional_info = args.max_additional_info
 
-    # fmt = "%(levelname)s %(message)s"
-    fmt = "%(message)s"
+    fmt = "%(levelname)s %(message)s"
     logging.basicConfig(stream=sys.stdout,
                         format=fmt,
                         level=getattr(logging, args.log_level.upper()))


### PR DESCRIPTION
Commit https://github.com/Kattis/problemtools/commit/cc02a135a464f2c7d01aa30ffb22b2d499280227 removed problemtools classifying if "bad things" are warnings or errors. I don't see a good reason not to be able to easily distinguish between them.

This PR reverts it.