### PR TITLE
Add type checking in our CI tests using `mypy`

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
@@ -44,3 +44,6 @@ jobs:
       run:  make builddeb
     - name: Test with pytest
       run:  pytest
+    - name: Run mypy
+      run: |
+        mypy --non-interactive --config-file mypy.ini -p problemtools

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,23 @@
+[mypy]
+ignore_missing_imports = True
+install_types = True
+check_untyped_defs = True
+ignore_errors = False
+
+[mypy-problemtools.tests.*]
+ignore_errors = True
+
+[mypy-problemtools.generatedata]
+ignore_errors = True
+
+[mypy-problemtools.languages]
+ignore_errors = True
+
+[mypy-problemtools.template]
+ignore_errors = True
+
+[mypy-problemtools.run.checktestdata]
+ignore_errors = True
+
+[mypy-problemtools.run.viva]
+ignore_errors = True

--- a/problemtools/ProblemPlasTeX/ProblemsetMacros.py
+++ b/problemtools/ProblemPlasTeX/ProblemsetMacros.py
@@ -69,7 +69,7 @@ class sampletableinteractive(Command):
     def read_sample_interaction(self, filename):
         data = io.open(filename, 'r', encoding='utf-8').read()
         messages = []
-        cur_msg = []
+        cur_msg: list[str] = []
         cur_mode = None
         for line in data.split('\n'):
             if not line: continue

--- a/problemtools/ProblemPlasTeX/__init__.py
+++ b/problemtools/ProblemPlasTeX/__init__.py
@@ -17,8 +17,8 @@ class ImageConverter(object):
     imageUnits = ''
 
     imageTypes = ['.png', '.jpg', '.jpeg', '.gif'] #, '.svg']
-    imageConversion = {'.pdf': ['.png',
-                                ['gs', '-dUseCropBox', '-sDEVICE=pngalpha', '-r300', '-o']]}
+    imageConversion = {'.pdf': ('.png',
+                                ['gs', '-dUseCropBox', '-sDEVICE=pngalpha', '-r300', '-o'])}
 
     def __init__(self, document):
         self.config = document.config

--- a/problemtools/config.py
+++ b/problemtools/config.py
@@ -24,7 +24,7 @@ def load_config(configuration_file):
             try:
                 with open(path, 'r') as config:
                     new_config = yaml.safe_load(config.read())
-            except (yaml.parser.ParserError, yaml.parser.ScannerError) as err:
+            except (yaml.parser.ParserError, yaml.scanner.ScannerError) as err:
                 raise ConfigError('Config file %s: failed to parse: %s' % (path, err))
         if res is None:
             if new_config is None:

--- a/problemtools/languages.py
+++ b/problemtools/languages.py
@@ -186,7 +186,7 @@ class Languages(object):
             list of files did not match any language in the set.
         """
         result = None
-        src = []
+        src: list[str] = []
         prio = 1e99
         for lang in self.languages.values():
             lang_src = lang.get_source_files(file_list)
@@ -236,7 +236,7 @@ class Languages(object):
             else:
                 self.languages[lang_id].update(lang_spec)
 
-        priorities = {}
+        priorities: dict[int, Language] = {}
         for (lang_id, lang) in self.languages.items():
             if lang.priority in priorities:
                 raise LanguageConfigError(

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -9,10 +9,12 @@ import threading
 
 from .errors import ProgramError
 
+from abc import ABC, abstractmethod
+
 log = logging.getLogger(__name__)
 
 
-class Program(object):
+class Program(ABC):
     """Abstract base class for programs.
     """
 
@@ -20,6 +22,10 @@ class Program(object):
         self.runtime = 0
         self._compile_lock = threading.Lock()
         self._compile_result: tuple[bool, str|None]|None = None
+
+    @abstractmethod
+    def get_runcmd(self, cwd = None, memlim = None) -> list[str]:
+        pass
 
     def run(self, infile='/dev/null', outfile='/dev/null', errfile='/dev/null',
             args=None, timelim=1000, memlim=1024, work_dir=None):

--- a/problemtools/tests/test_verify_hello.py
+++ b/problemtools/tests/test_verify_hello.py
@@ -12,5 +12,5 @@ def test_load_hello():
     with verify.Problem(string) as p:
         assert p.shortname == "hello"
         # pytest and fork don't go along very well, so just run aspects that work without run
-        assert p.classes[verify.ProblemConfig.PART_NAME].check(args)
-        assert p.classes[verify.Attachments.PART_NAME].check(args)
+        assert p.getProblemPart(verify.ProblemConfig).check(args)
+        assert p.getProblemPart(verify.Attachments).check(args)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -220,8 +220,8 @@ class TestCase(ProblemAspect):
         self._problem = problem
         self.testcasegroup = testcasegroup
         self.reuse_result_from: TestCase|None = None
-        self.counter = len(problem.classes[ProblemTestCases.PART_NAME].testcase_by_infile)
-        problem.classes[ProblemTestCases.PART_NAME].testcase_by_infile[self.infile] = self
+        self.counter = len(problem.getProblemPart(ProblemTestCases).testcase_by_infile)
+        problem.getProblemPart(ProblemTestCases).testcase_by_infile[self.infile] = self
 
     def check_newlines(self, filename: str) -> None:
         with open(filename, 'rb') as f:
@@ -259,7 +259,7 @@ class TestCase(ProblemAspect):
         self.check_newlines(self.ansfile)
         self.check_size_limits(self.infile)
         self.check_size_limits(self.ansfile)
-        self._problem.classes[InputValidators.PART_NAME].validate(self)
+        self._problem.getProblemPart(InputValidators).validate(self)
         anssize = os.path.getsize(self.ansfile) / 1024.0 / 1024.0
         outputlim = self._problem.get(ProblemConfig)['limits']['output']
         if anssize > outputlim:
@@ -267,7 +267,7 @@ class TestCase(ProblemAspect):
         elif 2 * anssize > outputlim:
             self.warning(f'Answer file ({anssize:.1f} Mb) is within 50% of output limit ({outputlim} Mb), you might want to increase output limit')
         if not self._problem.get(ProblemTestCases)['is_interactive']:
-            val_res = self._problem.classes[OutputValidators.PART_NAME].validate(self, self.ansfile)
+            val_res = self._problem.getProblemPart(OutputValidators).validate(self, self.ansfile)
             if val_res.verdict != 'AC':
                 if self.is_in_sample_group():
                     self.error(f'judge answer file got {val_res}')
@@ -286,8 +286,8 @@ class TestCase(ProblemAspect):
         if not os.path.islink(self.infile):
             return
         target = os.path.realpath(self.infile)
-        if target in self._problem.classes[ProblemTestCases.PART_NAME].testcase_by_infile:
-            self.reuse_result_from = self._problem.classes[ProblemTestCases.PART_NAME].testcase_by_infile[target]
+        if target in self._problem.getProblemPart(ProblemTestCases).testcase_by_infile:
+            self.reuse_result_from = self._problem.getProblemPart(ProblemTestCases).testcase_by_infile[target]
 
     def _check_symlinks(self) -> bool:
         if not os.path.islink(self.infile):
@@ -324,7 +324,7 @@ class TestCase(ProblemAspect):
     def run_submission_real(self, sub, context: Context, timelim: int, timelim_low: int, timelim_high: int) -> Result:
         # This may be called off-main thread.
         if self._problem.get(ProblemTestCases)['is_interactive']:
-            res_high = self._problem.classes[OutputValidators.PART_NAME].validate_interactive(self, sub, timelim_high, self._problem.classes[Submissions.PART_NAME])
+            res_high = self._problem.getProblemPart(OutputValidators).validate_interactive(self, sub, timelim_high, self._problem.getProblemPart(Submissions))
         else:
             outfile = os.path.join(self._problem.tmpdir, f'output-{self.counter}')
             errfile = os.path.join(self._problem.tmpdir, f'error-{self.counter}')
@@ -342,7 +342,7 @@ class TestCase(ProblemAspect):
                     info = None
                 res_high = SubmissionResult('RTE', additional_info=info)
             else:
-                res_high = self._problem.classes[OutputValidators.PART_NAME].validate(self, outfile)
+                res_high = self._problem.getProblemPart(OutputValidators).validate(self, outfile)
             res_high.runtime = runtime
 
         if res_high.runtime <= timelim_low:
@@ -510,10 +510,10 @@ class TestCaseGroup(ProblemAspect):
         if self.config['grading'] not in ['default', 'custom']:
             self.error("Invalid grading policy in testdata.yaml")
 
-        if self.config['grading'] == 'custom' and len(self._problem.classes[Graders.PART_NAME]._graders) == 0:
-            self._problem.classes[Graders.PART_NAME].error(f'{self} has custom grading but no custom graders provided')
+        if self.config['grading'] == 'custom' and len(self._problem.getProblemPart(Graders)._graders) == 0:
+            self._problem.getProblemPart(Graders).error(f'{self} has custom grading but no custom graders provided')
         if self.config['grading'] == 'default' and Graders._default_grader is None:
-            self._problem.classes[Graders.PART_NAME].error(f'{self} has default grading but I could not find default grader')
+            self._problem.getProblemPart(Graders).error(f'{self} has default grading but I could not find default grader')
 
         if self.config['grading'] == 'default' and 'ignore_sample' in self.config['grader_flags'].split():
             if self._parent is not None:
@@ -687,7 +687,7 @@ class TestCaseGroup(ProblemAspect):
             res.additional_info = judge_error.additional_info
             res.testcase = judge_error.testcase
         else:
-            res.verdict, score = self._problem.classes[Graders.PART_NAME].grade(sub_results, self, shadow_result)
+            res.verdict, score = self._problem.getProblemPart(Graders).grade(sub_results, self, shadow_result)
             if sub_results:
                 res.testcase = sub_results[-1].testcase
                 res.additional_info = sub_results[-1].additional_info
@@ -1658,7 +1658,7 @@ class Submissions(ProblemPart):
     def start_background_work(self, context: Context) -> None:
         # Send off an early background compile job for each submission and
         # validator, to avoid a bottleneck step at the start of each test run.
-        self.problem.classes[OutputValidators.PART_NAME].start_background_work(context)
+        self.problem.getProblemPart(OutputValidators).start_background_work(context)
         for acr in self._submissions:
             for sub in self._submissions[acr]:
                 context.submit_background_work(lambda s: s.compile(), sub)
@@ -1744,6 +1744,7 @@ PROBLEM_FORMATS: dict[str, dict[str, list[Type[ProblemPart]]]] = {
 # parts tested in alphabetical order
 PROBLEM_PARTS = [*sorted({part for format in PROBLEM_FORMATS.values() for part in format})]
 
+_ProblemPartT = TypeVar("_ProblemPartT", bound=ProblemPart)
 class Problem(ProblemAspect):
     """Represents a checkable problem"""
 
@@ -1768,6 +1769,9 @@ class Problem(ProblemAspect):
         assert part in self._data
         return self._data[part]
 
+    def getProblemPart(self, part: Type[_ProblemPartT]) -> _ProblemPartT:
+        return self._classes[part.PART_NAME] # type: ignore
+
     def __enter__(self) -> Problem:
         self.tmpdir = tempfile.mkdtemp(prefix=f'verify-{self.shortname}-')
         if not os.path.isdir(self.probdir):
@@ -1777,7 +1781,7 @@ class Problem(ProblemAspect):
 
         # Initialize the classes, making sure to resolve dependencies first
         initialized = set()
-        self.classes: dict[str, ProblemPart] = {}
+        self._classes: dict[str, ProblemPart] = {}
 
         def init(_class):
             if _class.PART_NAME in initialized:
@@ -1794,8 +1798,8 @@ class Problem(ProblemAspect):
                     raise NotImplementedError(f'Part "{_class.PART_NAME}" depends on part "{dependency.PART_NAME}" which showed up {cnt} times in problem-format (should have showed up exactly once)')
             self.debug(f'Initializing {_class.PART_NAME} ({_class})')
             assert _class.PART_NAME not in initialized
-            self.classes[_class.PART_NAME] = _class(self)
-            self._data[_class.PART_NAME] = self.classes[_class.PART_NAME].setup()
+            self._classes[_class.PART_NAME] = _class(self)
+            self._data[_class.PART_NAME] = self._classes[_class.PART_NAME].setup()
             initialized.add(_class.PART_NAME)
 
         for c in self.aspects:
@@ -1835,12 +1839,12 @@ class Problem(ProblemAspect):
             if executor:
                 for part in parts:
                     for item in self.part_mapping[part]:
-                        self.classes[item.PART_NAME].start_background_work(context)
+                        self._classes[item.PART_NAME].start_background_work(context)
 
             for part in parts:
                 self.msg(f'Checking {part}')
                 for item in self.part_mapping[part]:
-                    self.classes[item.PART_NAME].check(context)
+                    self._classes[item.PART_NAME].check(context)
         except VerifyError:
             pass
         finally:


### PR DESCRIPTION
This PR adds a type checking step to our CI tests using `mypy`.

For files where type checking flagged an error and it was obvious to me what the fix was, I fixed the problem. Otherwise, I (hopefully temporarily) used `ignore_errors` to avoid blowing up this PR completely.

The sole file with larger changes in this PR is `verifyproblem.py`, as I felt it was the most important file to get type checking coverage for. There, the way we access problemparts (introduced in #286) via `problem.classes` turned out to be particularly problematic. I know the intent is to follow up #286 with restructuring to avoid that access completely, but to get this past type checking in a decently clean way, I added a new method `getProblemPart` to replace access via `.classes`.