### PR TITLE
Fix mypy errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 *.pyc
 *~
+*.swp
 /.cache/
 /problemtools.egg-info/
 /support/default_validator/default_validator
 /support/interactive/interactive
 build/
+
+venv/
+.pytest_cache/
+.mypy_cache/

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,20 +4,5 @@ install_types = True
 check_untyped_defs = True
 ignore_errors = False
 
-[mypy-problemtools.tests.*]
-ignore_errors = True
-
 [mypy-problemtools.generatedata]
-ignore_errors = True
-
-[mypy-problemtools.languages]
-ignore_errors = True
-
-[mypy-problemtools.template]
-ignore_errors = True
-
-[mypy-problemtools.run.checktestdata]
-ignore_errors = True
-
-[mypy-problemtools.run.viva]
 ignore_errors = True

--- a/problemtools/languages.py
+++ b/problemtools/languages.py
@@ -52,7 +52,7 @@ class Language(object):
         """
         return [file_name for file_name in file_list
                 if (any(fnmatch.fnmatch(file_name, glob)
-                        for glob in self.files)
+                        for glob in self.files) # type: ignore[union-attr]
                     and
                     self.__matches_shebang(file_name))]
 
@@ -105,18 +105,13 @@ class Language(object):
         """
         # Check that all mandatory fields are provided
         if self.name is None:
-            raise LanguageConfigError(
-                'Language %s has no name' % self.lang_id)
+            raise LanguageConfigError(f'Language {self.lang_id} has no name')
         if self.priority is None:
-            raise LanguageConfigError(
-                'Language %s has no priority' % self.lang_id)
+            raise LanguageConfigError(f'Language {self.lang_id} has no priority')
         if self.files is None:
-            raise LanguageConfigError(
-
-        'Language %s has no files glob' % self.lang_id)
+            raise LanguageConfigError(f'Language {self.lang_id} has no files glob')
         if self.run is None:
-            raise LanguageConfigError(
-                'Language %s has no run command' % self.lang_id)
+            raise LanguageConfigError(f'Language {self.lang_id} has no run command')
 
         # Check that all variables appearing are valid
         variables = Language.__variables_in_command(self.run)

--- a/problemtools/run/checktestdata.py
+++ b/problemtools/run/checktestdata.py
@@ -41,8 +41,8 @@ class Checktestdata(Executable):
         return ((os.WIFEXITED(status) and os.WEXITSTATUS(status) in [0, 1]), None)
 
 
-    def run(self, infile='/dev/null', outfile='/dev/null',
-            errfile='/dev/null', args=None, timelim=1000):
+    def run(self, infile='/dev/null', outfile='/dev/null', errfile='/dev/null',
+            args=None, timelim=1000, memlim=1024, work_dir=None):
         """Run the Checktestdata script to validate an input file.
 
         Args:
@@ -66,7 +66,9 @@ class Checktestdata(Executable):
                                                            outfile=outfile,
                                                            errfile=errfile,
                                                            args=args,
-                                                           timelim=timelim)
+                                                           timelim=timelim,
+                                                           memlim=memlim,
+                                                           work_dir=work_dir)
         # This is ugly, switches the accept exit status and our accept
         # exit status 42.
         if os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0:

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -34,7 +34,7 @@ class Program(ABC):
         Args:
             infile (str): name of file to pass on stdin
             outfile (str): name of file to send stdout to
-            errfile (str): name of file to send stderr ro
+            errfile (str): name of file to send stderr to
             args (list of str): additional command-line arguments to
                 pass to the program
             timelim (int): CPU time limit in seconds

--- a/problemtools/run/viva.py
+++ b/problemtools/run/viva.py
@@ -40,8 +40,8 @@ class Viva(Executable):
         return ((os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0), None)
 
 
-    def run(self, infile='/dev/null', outfile='/dev/null',
-            errfile='/dev/null', args=None, timelim=1000):
+    def run(self, infile='/dev/null', outfile='/dev/null', errfile='/dev/null',
+            args=None, timelim=1000, memlim=1024, work_dir=None):
         """Run the VIVA script to validate an input file.
 
         Args:
@@ -68,7 +68,9 @@ class Viva(Executable):
         (status, runtime) = super(Viva, self).run(outfile=outfile,
                                                   errfile=errfile,
                                                   args=args,
-                                                  timelim=timelim)
+                                                  timelim=timelim,
+                                                  memlim=memlim,
+                                                  work_dir=work_dir)
         # This is ugly, switches the accept exit status and our accept
         # exit status 42.
         if os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0:

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -26,7 +26,7 @@ class Template:
         if glob.glob(os.path.join(stmtdir, 'problem.tex')):
             langs.append('')
         for f in glob.glob(os.path.join(stmtdir, 'problem.[a-z][a-z].tex')):
-            langs.append(re.search("problem.([a-z][a-z]).tex$", f).group(1))
+            langs.append(re.search("problem.([a-z][a-z]).tex$", f).group(1)) # type: ignore[union-attr]
         if len(langs) == 0:
             raise Exception('No problem statements available')
 
@@ -61,10 +61,10 @@ class Template:
         templatepaths = [os.path.join(os.path.dirname(__file__), 'templates/latex'),
                          os.path.join(os.path.dirname(__file__), '../templates/latex'),
                          '/usr/lib/problemtools/templates/latex']
-        self.templatepath = next((p for p in templatepaths
-                                  if os.path.isdir(p) and os.path.isfile(os.path.join(p, self.templatefile))),
-                                 None)
-        if self.templatepath is None:
+        try:
+            self.templatepath = next((p for p in templatepaths
+                                  if os.path.isdir(p) and os.path.isfile(os.path.join(p, self.templatefile))))
+        except StopIteration:
             raise Exception('Could not find directory with latex template "%s"' % self.templatefile)
 
         self.basedir = os.path.dirname(problemdir)

--- a/problemtools/tests/test_languages.py
+++ b/problemtools/tests/test_languages.py
@@ -34,7 +34,7 @@ class Language_test(TestCase):
         assert lang.files == ['*']
 
         lang.update({'shebang': 'new.*end'})
-        assert lang.shebang.match('newfilend')
+        assert lang.shebang is not None and lang.shebang.match('newfilend')
 
         with pytest.raises(languages.LanguageConfigError):
             # ambiguous entry point
@@ -52,9 +52,9 @@ class Language_test(TestCase):
     def test_invalid_id(self):
         vals = self.__language_dict()
         with pytest.raises(TypeError):
-            languages.Language(None, vals)
+            languages.Language(None, vals) # type: ignore
         with pytest.raises(TypeError):
-            languages.Language(42, vals)
+            languages.Language(42, vals) # type: ignore
         with pytest.raises(languages.LanguageConfigError):
             languages.Language('åäö', vals)
         with pytest.raises(languages.LanguageConfigError):

--- a/problemtools/tests/test_output_validator.py
+++ b/problemtools/tests/test_output_validator.py
@@ -13,7 +13,7 @@ def test_output_validator_feedback():
         text = "".join(r.choices(string.printable))
         feedback.write_text(text)
         data = OutputValidators._get_feedback(directory)
-        assert text in data
+        assert data is not None and text in data
 
 
 def test_output_validator_feedback_non_unicode():

--- a/problemtools/tests/test_verify_hello.py
+++ b/problemtools/tests/test_verify_hello.py
@@ -8,9 +8,10 @@ def test_load_hello():
 
     args = verify.argparser().parse_args([string])
     verify.initialize_logging(args)
+    context = verify.Context(args, None)
 
     with verify.Problem(string) as p:
         assert p.shortname == "hello"
         # pytest and fork don't go along very well, so just run aspects that work without run
-        assert p.getProblemPart(verify.ProblemConfig).check(args)
-        assert p.getProblemPart(verify.Attachments).check(args)
+        assert p.getProblemPart(verify.ProblemConfig).check(context)
+        assert p.getProblemPart(verify.Attachments).check(context)


### PR DESCRIPTION
Fixes (or ignores, where I felt that was more appropriate) type errors to allow us to run `mypy` on *almost* all files. After this PR, the only file ignored is `generatedata.py`, which is currently not working.

I also snuck in an updated gitignore, ignoring vim swap files and files created by python tooling.