### PR TITLE
Support 2023-07 config

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["pypy3.10", "3.10"] # Arbitrary pick of one pypy and one Cpython version
+        python-version: ["pypy3.11", "3.11"] # 3.11 is the lowest we support, since we want StrEnum
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ problemtools' configuration:
    are not sure whether you should use it, then you probably shouldn't.
    This file can be used to specify the system defaults for those
    problem limits which are not given a fixed default value in the
-   [problem format specification](http://www.problemarchive.org/wiki/index.php/Problem_Format#limits).
+   [problem format specification](https://www.kattis.com/problem-package-format/spec/2023-07-draft.html#limits).
    The system defaults assumed by problemtools can be found in
    (problemtools/config/problem.yaml).  For instance, if you are
    primarily working against a system with a default memory limit of 2 GiB,
@@ -190,10 +190,6 @@ problemtools' configuration:
    limits:
        memory: 2048 # (unit is MiB)
    ```
-
-   (In principle, it is possible to override the defaults of other values than the
-   system-dependent defaults in the problem.yaml metadata files this way, but such
-   usage is very strongly discouraged.)
 
 
 ## Requirements and compatibility

--- a/problemtools/config/problem.yaml
+++ b/problemtools/config/problem.yaml
@@ -1,32 +1,9 @@
-uuid: ''
-type: pass-fail
-author: ''
-source: ''
-source_url: ''
-license: unknown
-rights_owner: ''
-
-validation: default
-validator_flags: ''
-
 limits:
-   time_multiplier: 5
-   time_safety_margin: 2
    memory: 1024
    output: 8
    code: 128
    compilation_time: 60
+   compilation_memory: 1024
    validation_time: 60
    validation_memory: 1024
    validation_output: 8
-
-keywords: ''
-
-grading:
-   objective: max
-   show_test_data_groups: False
-
-languages: all
-
-# These are in the spec but currently unsupported
-libraries: ''

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 
 VERSION_LEGACY = "legacy"
-VERSION_2023_07 = "2023-07"
+VERSION_2023_07 = "2023-07-draft"
 
 
 @dataclass(frozen=True)
@@ -24,9 +24,10 @@ FORMAT_DATACLASSES = {
     VERSION_LEGACY: FormatData(name=VERSION_LEGACY, statement_directory="problem_statement", statement_extensions=["tex"]),
     VERSION_2023_07: FormatData(name=VERSION_2023_07, statement_directory="statement", statement_extensions=["md", "tex"])
 }
+FORMAT_DATACLASSES['2023-07'] = FORMAT_DATACLASSES[VERSION_2023_07] # Accept non-draft version string too
 
 
-def detect_problem_version(path) -> str:
+def detect_problem_version(path: str) -> str:
     """
     Returns the problem version value of problem.yaml or throws an error if it is unable to read the file.
     Args:
@@ -45,7 +46,7 @@ def detect_problem_version(path) -> str:
     return config.get('problem_format_version', VERSION_LEGACY)
 
 
-def get_format_data(path):
+def get_format_data(path: str) -> FormatData:
     """
     Gets the dataclass object containing the necessary data for a problem format.
     Args:
@@ -58,7 +59,7 @@ def get_format_data(path):
     return get_format_data_by_name(detect_problem_version(path))
 
 
-def get_format_data_by_name(name):
+def get_format_data_by_name(name: str) -> FormatData:
     """
     Gets the dataclass object containing the necessary data for a problem format given the format name.
     Args:

--- a/problemtools/metadata.py
+++ b/problemtools/metadata.py
@@ -1,0 +1,307 @@
+import copy
+import datetime
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Literal, Self, Type, Union
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from . import config
+from . import formatversion
+
+class ProblemType(StrEnum):
+    PASS_FAIL = 'pass-fail'
+    SCORING = 'scoring'
+    MULTI_PASS = 'multi-pass'
+    INTERACTIVE = 'interactive'
+    SUBMIT_ANSWER = 'submit-answer'
+
+class License(StrEnum):
+    UNKNOWN = 'unknown'
+    PUBLIC_DOMAIN = 'public domain'
+    CC0 = 'cc0'
+    CC_BY = 'cc by'
+    CC_BY_SA = 'cc by-sa'
+    EDUCATIONAL = 'educational'
+    PERMISSION = 'permission'
+
+@dataclass
+class Person:
+    name: str
+    email: str | None = None
+    orcid: str | None = None
+    kattis: str | None = None
+
+    @classmethod
+    def from_string(cls: Type[Self], s: str) -> Self:
+        match = re.match(r'^(.*?)\s+<(.*)>$', s.strip())
+        if match:
+            return cls(name = match.group(1), email = match.group(2))
+        return cls(name = s)
+
+@dataclass
+class Source:
+    name: str
+    url: str | None = None
+
+@dataclass
+class TimeMultipliers:
+    ac_to_time_limit: float = 2.0
+    time_limit_to_tle: float = 1.5
+
+@dataclass
+class Limits:
+    memory: int
+    output: int
+    code: int
+    compilation_time: int
+    compilation_memory: int
+    validation_time: int
+    validation_memory: int
+    validation_output: int
+    time_multipliers: TimeMultipliers = field(default_factory=TimeMultipliers)
+    time_limit: float | None = None
+    time_resolution: float = 1.0
+    validation_passes: int = 2
+
+@dataclass
+class Credits:
+    """
+    Credits format where all persons have been converted to Person objects.
+    For use in our internal representation.
+    """
+    authors: list[Person] = field(default_factory=list)
+    contributors: list[Person] = field(default_factory=list)
+    testers: list[Person] = field(default_factory=list)
+    translators: dict[str, list[Person]] = field(default_factory=dict)
+    packagers: list[Person] = field(default_factory=list)
+    acknowledgements: list[Person] = field(default_factory=list)
+
+@dataclass
+class InputCredits:
+    """
+    A more permissive dataclass for credits, as the input in 2023-07 looks.
+    For use when validating input.
+    """
+    # Type in the input format is messy
+    PersonOrPersons = Union[str | list[Union[Person, str]]]
+
+    authors: PersonOrPersons = field(default_factory=list)
+    contributors: PersonOrPersons = field(default_factory=list)
+    testers: PersonOrPersons = field(default_factory=list)
+    translators: dict[str, PersonOrPersons] = field(default_factory=dict)
+    packagers: PersonOrPersons = field(default_factory=list)
+    acknowledgements: PersonOrPersons = field(default_factory=list)
+
+class Metadata2023_07(BaseModel):
+    """
+    The metadata for a problem as input in version 2023-07-draft.
+    """
+
+    problem_format_version: str
+    name: dict[str, str] | str
+    uuid: UUID
+    type: list[ProblemType] | ProblemType = ProblemType.PASS_FAIL
+    version: str | None = None
+    credits: dict | str | None = None
+    source: list[Union[str, Source]] | Source | str = []
+    license: License = License.UNKNOWN
+    rights_owner: str | None = None
+    embargo_until: datetime.datetime | None = None
+    limits: Limits
+    keywords: list[str] = []
+    languages: list[str] | Literal['all'] = 'all'
+    allow_file_writing: bool = True
+    constants: dict[str, int | float | str] = {}
+
+    model_config = ConfigDict(extra='forbid')
+
+@dataclass
+class LegacyGrading:
+    objective: Literal['max', 'min'] = 'max'
+    show_test_data_groups: bool = False
+    # These 3 fields predate the version called "legacy"
+    accept_score: float | None = None
+    reject_score: float | None = None
+    range: str | None = None
+    on_reject: Literal['first_error', 'worst_error', 'grade'] | None = None
+
+@dataclass
+class LegacyLimits:
+    memory: int
+    output: int
+    code: int
+    compilation_time: int
+    compilation_memory: int
+    validation_time: int
+    validation_memory: int
+    validation_output: int
+    time_multiplier: float = 5.0
+    time_safety_margin: float = 2.0
+
+class MetadataLegacy(BaseModel):
+    """
+    The metadata for a problem as input in version legacy (plus a few fields
+    which pre-date the version called legacy).
+    """
+
+    problem_format_version: str = formatversion.VERSION_LEGACY
+    type: Literal['pass-fail'] | Literal['scoring'] = 'pass-fail'
+    name: str | None = None
+    uuid: UUID | None = None
+    author: str | None = None
+    source: str | None = None
+    source_url: str | None = None
+    license: License = License.UNKNOWN
+    rights_owner: str | None = None
+    limits: LegacyLimits
+    validation: str = 'default'
+    validator_flags: str = ''
+    grading: LegacyGrading = LegacyGrading()
+    keywords: str = ''
+
+    model_config = ConfigDict(extra='forbid')
+
+class Metadata(BaseModel):
+    """
+    The metadata for a problem, as used internally in problemtools. Closely
+    follows the 2023-07-draft version, but is more fully parsed, and adds
+    a few legacy fields to represent information not in 2023-07.
+
+    Metadata serializes to a valid 2023-07-draft configuration.
+    """
+
+    problem_format_version: str
+    type: list[str]
+    name: dict[str,str]
+    uuid: UUID | None
+    version: str | None
+    credits: Credits
+    source: list[Source]
+    license: License
+    rights_owner: str | None
+    embargo_until: datetime.datetime | None
+    limits: Limits
+    keywords: list[str]
+    languages: list[str] | Literal['all']
+    allow_file_writing: bool
+    constants: dict
+    legacy_grading: LegacyGrading = Field(default_factory=LegacyGrading, exclude=True)
+    legacy_validation: str = Field(default = '', exclude=True)
+    legacy_validator_flags: str = Field(default = '', exclude=True)
+    legacy_custom_score: bool = Field(default = False, exclude=True) # True iff legacy_validation is custom and score.
+
+    model_config = ConfigDict(extra='forbid')
+
+    def is_pass_fail(self) -> bool:
+        return not self.is_scoring()
+
+    def is_scoring(self) -> bool:
+        return ProblemType.SCORING in self.type
+
+    def is_interactive(self) -> bool:
+        return ProblemType.INTERACTIVE in self.type
+
+    @classmethod
+    def from_legacy(cls: Type[Self], legacy: MetadataLegacy, names_from_statements: dict[str, str]) -> Self:
+        metadata = legacy.model_dump()
+        metadata['type'] = [metadata['type']]
+        # Support for *ancient* problems where names_from_statements is empty
+        metadata['name'] = names_from_statements if names_from_statements else {'': metadata['name']}
+        metadata['version'] = None
+
+        def parse_author_field(author: str) -> list[Person]:
+            authors = re.split(r',\s*|\s+and\s+|\s+&\s+', author)
+            authors = [x.strip(' \t\r\n') for x in authors]
+            authors = [x for x in authors if len(x) > 0]
+            return [Person.from_string(author) for author in authors]
+
+        metadata['credits'] = {}
+        if metadata['author'] is not None:
+            metadata['credits']['authors'] = parse_author_field(metadata['author'])
+        del metadata['author']
+        metadata['source'] = [] if metadata['source'] is None else [Source(metadata['source'], metadata['source_url'])]
+        del metadata['source_url']
+        metadata['embargo_until'] = None
+        metadata['limits']['time_multipliers'] = {
+            'ac_to_time_limit': metadata['limits']['time_multiplier'],
+            'time_limit_to_tle': metadata['limits']['time_safety_margin'],
+        }
+        del metadata['limits']['time_multiplier']
+        del metadata['limits']['time_safety_margin']
+        metadata['keywords'] = metadata['keywords'].split()
+        metadata['languages'] = 'all'
+        metadata['allow_file_writing'] = True
+        metadata['constants'] = {}
+
+        # The interactive flag from validation now lives in type, copy it over.
+        validation = metadata['validation'].split()
+        if validation[0] == 'custom':
+            if 'interactive' in validation[1:]:
+                metadata['type'].append('interactive')
+            if 'score' in validation[1:]:
+                metadata['legacy_custom_score'] = True
+        # Copy over the legacy info that does not fit cleanly
+        for key in 'grading', 'validator_flags', 'validation':
+            metadata[f'legacy_{key}'] = metadata[key]
+            del metadata[key]
+        return cls.model_validate(metadata)
+
+    @classmethod
+    def from_2023_07(cls: Type[Self], md2023_07: Metadata2023_07) -> Self:
+        metadata = md2023_07.model_dump()
+        metadata['type'] = [metadata['type']] if isinstance(metadata['type'], str) else metadata['type']
+        metadata['name'] = {'en' : metadata['name']} if isinstance(metadata['name'], str) else metadata['name']
+
+        def parse_source(source: str | Source) -> Source:
+            return Source(name=source, url=None) if isinstance(source, str) else source
+
+        # Convenience function to deal with the fact that lists of persons/sources are
+        # either a string, or a list of strings or dicts (if dicts, pydantic
+        # already parsed those for us).
+        def parse_list(callback, lst: str | list) -> list:
+            if isinstance(lst, str):
+                return [callback(lst)]
+            return list(map(callback, lst))
+
+        metadata['source'] = parse_list(parse_source, metadata['source'])
+
+        def parse_person(person: str | Person) -> Person:
+            return Person.from_string(person) if isinstance(person, str) else person
+
+        if metadata['credits'] is None:
+            metadata['credits'] = {}
+        elif isinstance(metadata['credits'], str):
+            metadata['credits'] = {'authors': [parse_person(metadata['credits'])]}
+        else:
+            for key in metadata['credits']:
+                if key == 'translators': # special case, we nest deeper here
+                    for lang in metadata['credits'][key]:
+                        metadata['credits'][key][lang] = parse_list(parse_person, metadata['credits'][key][lang])
+                else:
+                    metadata['credits'][key] = parse_list(parse_person, metadata['credits'][key])
+        return cls.model_validate(metadata)
+
+def parse_metadata(version: formatversion.FormatData, problem_yaml_data: dict[str, Any], names_from_statements: dict[str, str]) -> Metadata:
+    """
+    Parses a data structure from problem.yaml into a Metadata model
+    :raises pydantic.ValidationError: We intentionally leak pydantic's exception on errors, as it's well designed
+    """
+
+    # We need to mix in the system default config values before doing model validation
+    data = copy.deepcopy(problem_yaml_data)
+    # Check if the user has done something silly like making limits a string. If so, we
+    # don't merge in anything, and let pydantic complain later.
+    if isinstance(data.get('limits', {}), dict):
+        system_defaults = config.load_config('problem.yaml')
+        data['limits'] = system_defaults['limits'] | data.get('limits', {})
+
+    if version.name == formatversion.VERSION_LEGACY:
+        legacy_model = MetadataLegacy.model_validate(data)
+        return Metadata.from_legacy(legacy_model, names_from_statements)
+    else:
+        assert version.name == formatversion.VERSION_2023_07
+        model_2023_07 = Metadata2023_07.model_validate(data)
+        return Metadata.from_2023_07(model_2023_07)

--- a/problemtools/tests/test_metadata.py
+++ b/problemtools/tests/test_metadata.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from pydantic import ValidationError
+from problemtools import formatversion, metadata
+
+# A few quick tests of config parsing. pytest structure isn't great here, so code gets repetitive, but I wanted *something* basic in place at least.
+
+def test_parse_empty_legacy():
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_LEGACY), {}, {'en': 'Hello World!'})
+    # Just check off a few random things
+    assert m.name['en'] == 'Hello World!'
+    assert not m.source
+    assert not m.credits.authors
+
+def test_parse_empty_2023_fails():
+    with pytest.raises(ValidationError):
+        m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), {}, {'en': 'Hello World!'})
+
+@pytest.fixture
+def minimal_2023_conf():
+    return {
+        'problem_format_version': '2023-07-draft',
+        'uuid': '46fa942f-44c3-46c0-8ddc-22e02d2e5d2b',
+        'name': { 'en': 'Hello World!' },
+        }
+
+def test_parse_minimal_2023(minimal_2023_conf):
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), minimal_2023_conf, {'en': 'Hello World!'})
+    assert m.name['en'] == 'Hello World!'
+    assert not m.source
+    assert not m.credits.authors
+
+def test_parse_typo_fails(minimal_2023_conf):
+    c = minimal_2023_conf
+    c['limits'] = { 'typo': 1 }
+    with pytest.raises(ValidationError):
+        m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), c, {'en': 'Hello World!'})
+
+def test_parse_single_author_2023(minimal_2023_conf):
+    c = minimal_2023_conf
+    c['credits'] = ' \t  Authy McAuth \t <authy@mcauth.example> \t\t  ' # Add some extra whitespace to check that we strip
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), c, {'en': 'Hello World!'})
+    assert len(m.credits.authors) == 1
+    assert m.credits.authors[0].name == 'Authy McAuth'
+    assert m.credits.authors[0].email == 'authy@mcauth.example'
+
+def test_parse_single_source_2023(minimal_2023_conf):
+    c = minimal_2023_conf
+    c['source'] = 'NWERC 2024'
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), c, {'en': 'Hello World!'})
+    assert len(m.source) == 1
+    assert m.source[0].name == 'NWERC 2024'
+    assert m.source[0].url is None
+
+def test_parse_multi_source(minimal_2023_conf):
+    c = minimal_2023_conf
+    c['source'] = [
+        {'name': 'NWERC 2024', 'url': 'https://2024.nwerc.example/contest'},
+        'SWERC 2024',
+        {'name': 'SEERC 2024'},
+    ]
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), c, {'en': 'Hello World!'})
+    assert len(m.source) == 3
+    assert m.source[0].name == 'NWERC 2024'
+    assert m.source[0].url == 'https://2024.nwerc.example/contest'
+    assert m.source[1].name == 'SWERC 2024'
+    assert m.source[1].url is None
+    assert m.source[2].name == 'SEERC 2024'
+    assert m.source[2].url is None

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -26,16 +26,17 @@ import shlex
 
 import yaml
 
-from . import problem2pdf
-from . import problem2html
-from . import formatversion
-
 from . import config
 from . import languages
+from . import formatversion
+from . import metadata
+from . import problem2html
+from . import problem2pdf
 from . import run
 
 from abc import ABC
 from typing import Any, Callable, ClassVar, Literal, Pattern, Match, ParamSpec, Type, TypeVar
+from pydantic import ValidationError
 
 log = logging.getLogger(__name__)
 
@@ -262,7 +263,7 @@ class TestCase(ProblemAspect):
         self.check_size_limits(self.ansfile)
         self._problem.getProblemPart(InputValidators).validate(self)
         anssize = os.path.getsize(self.ansfile) / 1024.0 / 1024.0
-        outputlim = self._problem.get(ProblemConfig)['limits']['output']
+        outputlim = self._problem.getMetadata().limits.output
         if anssize > outputlim:
             self.error(f'Answer file ({anssize:.1f} Mb) is larger than output limit ({outputlim} Mb), you need to increase output limit')
         elif 2 * anssize > outputlim:
@@ -331,7 +332,7 @@ class TestCase(ProblemAspect):
             errfile = os.path.join(self._problem.tmpdir, f'error-{self.counter}')
             status, runtime = sub.run(infile=self.infile, outfile=outfile, errfile=errfile,
                                       timelim=timelim_high+1,
-                                      memlim=self._problem.get(ProblemConfig)['limits']['memory'], work_dir=sub.path)
+                                      memlim=self._problem.getMetadata().limits.memory, work_dir=sub.path)
             if is_TLE(status) or runtime > timelim_high:
                 res_high = SubmissionResult('TLE')
             elif is_RTE(status):
@@ -422,18 +423,18 @@ class TestCaseGroup(ProblemAspect):
 
         # TODO: Decide if these should stay
         # Some deprecated properties are inherited from problem config during a transition period
-        problem_grading = problem.get(ProblemConfig)['grading']
+        legacy_grading = problem.getMetadata().legacy_grading
         for key in ['accept_score', 'reject_score', 'range']:
-            if key in problem.get(ProblemConfig)['grading']:
-                self.config[key] = problem_grading[key]
+            if getattr(legacy_grading, key) is not None:
+                self.config[key] = getattr(legacy_grading, key)
 
-        problem_on_reject = problem_grading.get('on_reject')
+        problem_on_reject = legacy_grading.on_reject
         if problem_on_reject == 'first_error':
             self.config['on_reject'] = 'break'
         if problem_on_reject == 'grade':
             self.config['on_reject'] = 'continue'
 
-        if self._problem.get(ProblemConfig)['type'] == 'pass-fail':
+        if self._problem.getMetadata().is_pass_fail():
             for key in TestCaseGroup._SCORING_ONLY_KEYS:
                 if key not in self.config:
                     self.config[key] = None
@@ -789,15 +790,11 @@ class ProblemConfig(ProblemPart):
     def setup_dependencies():
         return {ProblemStatement}
 
-    _MANDATORY_CONFIG = ['name']
-    _OPTIONAL_CONFIG = config.load_config('problem.yaml')
-    _VALID_LICENSES = ['unknown', 'public domain', 'cc0', 'cc by', 'cc by-sa', 'educational', 'permission']
-
     def setup(self):
         self.debug('  Loading problem config')
         self.configfile = os.path.join(self.problem.probdir, 'problem.yaml')
-        self._data = {}
 
+        self._data = {}
         if os.path.isfile(self.configfile):
             try:
                 with open(self.configfile) as f:
@@ -807,44 +804,24 @@ class ProblemConfig(ProblemPart):
                     self._data = {}
             except Exception as e:
                 self.error(str(e))
-
-        # Add config items from problem statement e.g. name
-        self._data.update(self.problem.get(ProblemStatement))
-
-        # Populate rights_owner unless license is public domain
-        if 'rights_owner' not in self._data and self._data.get('license') != 'public domain':
-            if 'author' in self._data:
-                self._data['rights_owner'] = self._data['author']
-            elif 'source' in self._data:
-                self._data['rights_owner'] = self._data['source']
-
-        if 'license' in self._data:
-            self._data['license'] = self._data['license'].lower()
-
-        # Ugly backwards compatibility hack
-        if 'name' in self._data and not isinstance(self._data['name'], dict):
-            self._data['name'] = {'': self._data['name']}
+        else:
+            # This should likely be a fatal error, but I'm not sure there's a clean way to fail from setup
+            self.error(f"No config file {self.configfile} found")
 
         self._origdata = copy.deepcopy(self._data)
 
-        for field, default in copy.deepcopy(ProblemConfig._OPTIONAL_CONFIG).items():
-            if not field in self._data:
-                self._data[field] = default
-            elif isinstance(default, dict) and isinstance(self._data[field], dict):
-                self._data[field] = dict(list(default.items()) + list(self._data[field].items()))
-
-        val = self._data['validation'].split()
-        self._data['validation-type'] = val[0]
-        self._data['validation-params'] = val[1:]
-
-        self._data['grading']['custom_scoring'] = False
-        for param in self._data['validation-params']:
-            if param == 'score':
-                self._data['grading']['custom_scoring'] = True
-            elif param == 'interactive':
-                pass
-
-        return self._data
+        try:
+            self._metadata = metadata.parse_metadata(
+                    formatversion.get_format_data(self.problem.probdir),
+                    self._data,
+                    self.problem.get(ProblemStatement).get('name', {}),
+            )
+            self.problem.setMetadata(self._metadata)
+        except ValidationError as e:
+            # This should likely be a fatal error, but I'm not sure there's a clean way to fail from setup
+            error_str = '\n'.join([f"    {'->'.join(str(err['loc']))}: {err['msg']}" for err in e.errors()])
+            self.error(f'Failed parsing problem.yaml. Found {len(e.errors())} errors:\n{error_str}')
+        return {}
 
 
     def __str__(self) -> str:
@@ -855,84 +832,48 @@ class ProblemConfig(ProblemPart):
             return self._check_res
         self._check_res = True
 
-        if not os.path.isfile(self.configfile):
-            self.error(f"No config file {self.configfile} found")
-
-        for field in ProblemConfig._MANDATORY_CONFIG:
-            if not field in self._data:
-                self.error(f"Mandatory field '{field}' not provided")
-
-        for field, value in self._origdata.items():
-            if field not in ProblemConfig._OPTIONAL_CONFIG.keys() and field not in ProblemConfig._MANDATORY_CONFIG:
-                self.warning(f"Unknown field '{field}' provided in problem.yaml")
-
-        for field, value in self._data.items():
-            if value is None:
-                self.error(f"Field '{field}' provided in problem.yaml but is empty")
-                self._data[field] = ProblemConfig._OPTIONAL_CONFIG.get(field, '')
-
-        # Check type
-        if not self._data['type'] in ['pass-fail', 'scoring']:
-            self.error(f"Invalid value '{self._data['type']}' for type")
-
         # Check rights_owner
-        if self._data['license'] == 'public domain':
-            if self._data['rights_owner'].strip() != '':
+        if self._metadata.license == metadata.License.PUBLIC_DOMAIN:
+            if self._metadata.rights_owner:
                 self.error('Can not have a rights_owner for a problem in public domain')
-        elif self._data['license'] != 'unknown':
-            if self._data['rights_owner'].strip() == '':
+        elif self._metadata.license != metadata.License.UNKNOWN:
+            if not self._metadata.rights_owner and not self._metadata.source and not self._metadata.credits.authors:
                 self.error('No author, source or rights_owner provided')
 
-        # Check source_url
-        if (self._data['source_url'].strip() != '' and
-            self._data['source'].strip() == ''):
-            self.error('Can not provide source_url without also providing source')
-
         # Check license
-        if not self._data['license'] in ProblemConfig._VALID_LICENSES:
-            self.error(f"Invalid value for license: {self._data['license']}.\n  Valid licenses are {ProblemConfig._VALID_LICENSES}")
-        elif self._data['license'] == 'unknown':
+        if self._metadata.license == metadata.License.UNKNOWN:
             self.warning("License is 'unknown'")
 
-        if self._data['grading']['show_test_data_groups'] not in [True, False]:
-            self.error(f"Invalid value for grading.show_test_data_groups: {self._data['grading']['show_test_data_groups']}")
-        elif self._data['grading']['show_test_data_groups'] and self._data['type'] == 'pass-fail':
+        if self._metadata.legacy_grading.show_test_data_groups and self._metadata.is_pass_fail():
             self.error("Showing test data groups is only supported for scoring problems, this is a pass-fail problem")
-        if self._data['type'] != 'pass-fail' and self.problem.get(ProblemTestCases)['root_group'].has_custom_groups() and 'show_test_data_groups' not in self._origdata.get('grading', {}):
+        if not self._metadata.is_pass_fail() and self.problem.get(ProblemTestCases)['root_group'].has_custom_groups() and 'show_test_data_groups' not in self._origdata.get('grading', {}):
             self.warning("Problem has custom testcase groups, but does not specify a value for grading.show_test_data_groups; defaulting to false")
 
-        if 'on_reject' in self._data['grading']:
-            if self._data['type'] == 'pass-fail' and self._data['grading']['on_reject'] == 'grade':
-                self.error(f"Invalid on_reject policy '{self._data['grading']['on_reject']}' for problem type '{self._data['type']}'")
-            if not self._data['grading']['on_reject'] in ['first_error', 'worst_error', 'grade']:
-                self.error(f"Invalid value '{self._data['grading']['on_reject']}' for on_reject policy")
-
-        if self._data['grading']['objective'] not in ['min', 'max']:
-            self.error(f"Invalid value '{self._data['grading']['objective']}' for objective")
+        if self._metadata.legacy_grading.on_reject is not None:
+            if self._metadata.is_pass_fail() and self._metadata.legacy_grading.on_reject == 'grade':
+                self.error("Invalid on_reject policy 'grade' for problem type 'pass-fail'")
 
         for deprecated_grading_key in ['accept_score', 'reject_score', 'range', 'on_reject']:
-            if deprecated_grading_key in self._data['grading']:
+            if getattr(self._metadata.legacy_grading, deprecated_grading_key) is not None:
                 self.warning(f"Grading key '{deprecated_grading_key}' is deprecated in problem.yaml, use '{deprecated_grading_key}' in testdata.yaml instead")
 
-        if not self._data['validation-type'] in ['default', 'custom']:
-            self.error(f"Invalid value '{self._data['validation']}' for validation, first word must be 'default' or 'custom'")
+        if self._metadata.legacy_validation:
+            val = self._metadata.legacy_validation.split()
+            validation_type = val[0]
+            validation_params = val[1:]
+            if not validation_type in ['default', 'custom']:
+                self.error(f"Invalid value '{validation_type}' for validation, first word must be 'default' or 'custom'")
 
-        if self._data['validation-type'] == 'default' and len(self._data['validation-params']) > 0:
-            self.error(f"Invalid value '{self._data['validation']}' for validation")
+            if validation_type == 'default' and len(validation_params) > 0:
+                self.error(f"Invalid value '{self._metadata.legacy_validation}' for validation")
 
-        if self._data['validation-type'] == 'custom':
-            for param in self._data['validation-params']:
-                if param not in['score', 'interactive']:
-                    self.error(f"Invalid parameter '{param}' for custom validation")
+            if validation_type == 'custom':
+                for param in validation_params:
+                    if param not in ['score', 'interactive']:
+                        self.error(f"Invalid parameter '{param}' for custom validation")
 
-        # Check limits
-        if not isinstance(self._data['limits'], dict):
-            self.error('Limits key in problem.yaml must specify a dict')
-            self._data['limits'] = ProblemConfig._OPTIONAL_CONFIG['limits']
-
-        # Some things not yet implemented
-        if self._data['libraries'] != '':
-            self.error("Libraries not yet supported")
+        if self._metadata.limits.time_limit is not None and not self._metadata.limits.time_limit.is_integer():
+            self.warning(f'Time limit configured to non-integer value. Problemtools does not yet support non-integer time limits, and will truncate')
 
         return self._check_res
 
@@ -948,8 +889,8 @@ class ProblemTestCases(ProblemPart):
         self.testcase_by_infile = {}
         return {
                 'root_group': TestCaseGroup(self.problem, self.PART_NAME),
-                'is_interactive': 'interactive' in self.problem.get(ProblemConfig)['validation-params'],
-                'is_scoring': self.problem.get(ProblemConfig)['type'] == 'scoring'
+                'is_interactive': self.problem.getMetadata().is_interactive(),
+                'is_scoring': self.problem.getMetadata().is_scoring(),
                 }
 
     def check(self, context: Context) -> bool:
@@ -1162,7 +1103,7 @@ class Graders(ProblemPart):
             return self._check_res
         self._check_res = True
 
-        if self.problem.get(ProblemConfig)['type'] == 'pass-fail' and len(self._graders) > 0:
+        if self.problem.getMetadata().is_pass_fail() and len(self._graders) > 0:
             self.error('There are grader programs but the problem is pass-fail')
 
         for grader in self._graders:
@@ -1269,12 +1210,12 @@ class OutputValidators(ProblemPart):
             if isinstance(v, run.SourceCode) and v.language.lang_id not in recommended_output_validator_languages:
                 self.warning('output validator language %s is not recommended' % v.language.name)
 
-        if self.problem.get(ProblemConfig)['validation'] == 'default' and self._validators:
+        if self.problem.getMetadata().legacy_validation == 'default' and self._validators:
             self.error('There are validator programs but problem.yaml has validation = "default"')
-        elif self.problem.get(ProblemConfig)['validation'] != 'default' and not self._validators:
+        elif self.problem.getMetadata().legacy_validation != 'default' and not self._validators:
             self.error('problem.yaml specifies custom validator but no validator programs found')
 
-        if self.problem.get(ProblemConfig)['validation'] == 'default' and self._default_validator is None:
+        if self.problem.getMetadata().legacy_validation == 'default' and self._default_validator is None:
             self.error('Unable to locate default validator')
 
         for val in self._validators[:]:
@@ -1287,7 +1228,7 @@ class OutputValidators(ProblemPart):
 
         # Only sanity check output validators if they all actually compiled
         if self._check_res:
-            flags = self.problem.get(ProblemConfig)['validator_flags']
+            flags = self.problem.getMetadata().legacy_validator_flags
 
             fd, file_name = tempfile.mkstemp()
             os.close(fd)
@@ -1329,7 +1270,7 @@ class OutputValidators(ProblemPart):
 
 
     def _parse_validator_results(self, val, status: int, feedbackdir, testcase: TestCase) -> SubmissionResult:
-        custom_score = self.problem.get(ProblemConfig)['grading']['custom_scoring']
+        custom_score = self.problem.getMetadata().legacy_custom_score
         score = None
         # TODO: would be good to have some way of displaying the feedback for debugging uses
         score_file = os.path.join(feedbackdir, 'score.txt')
@@ -1364,7 +1305,7 @@ class OutputValidators(ProblemPart):
 
     def _actual_validators(self) -> list:
         vals = self._validators
-        if self.problem.get(ProblemConfig)['validation'] == 'default':
+        if self.problem.getMetadata().legacy_validation == 'default':
             vals = [self._default_validator]
         return [val for val in vals if val is not None]
 
@@ -1380,10 +1321,10 @@ class OutputValidators(ProblemPart):
         # file descriptor, wall time lim
         initargs = ['1', str(2 * timelim)]
         validator_args = [testcase.infile, testcase.ansfile, '<feedbackdir>']
-        submission_args = submission.get_runcmd(memlim=self.problem.get(ProblemConfig)['limits']['memory'])
+        submission_args = submission.get_runcmd(memlim=self.problem.getMetadata().limits.memory)
 
-        val_timelim = self.problem.get(ProblemConfig)['limits']['validation_time']
-        val_memlim = self.problem.get(ProblemConfig)['limits']['validation_memory']
+        val_timelim = self.problem.getMetadata().limits.validation_time
+        val_memlim = self.problem.getMetadata().limits.validation_memory
         for val in self._actual_validators():
             if val.compile()[0]:
                 feedbackdir = tempfile.mkdtemp(prefix='feedback', dir=self.problem.tmpdir)
@@ -1435,9 +1376,9 @@ class OutputValidators(ProblemPart):
 
     def validate(self, testcase: TestCase, submission_output: str) -> SubmissionResult:
         res = SubmissionResult('JE')
-        val_timelim = self.problem.get(ProblemConfig)['limits']['validation_time']
-        val_memlim = self.problem.get(ProblemConfig)['limits']['validation_memory']
-        flags = self.problem.get(ProblemConfig)['validator_flags'].split() + testcase.testcasegroup.config['output_validator_flags'].split()
+        val_timelim = self.problem.getMetadata().limits.validation_time
+        val_memlim = self.problem.getMetadata().limits.validation_memory
+        flags = self.problem.getMetadata().legacy_validator_flags.split() + testcase.testcasegroup.config['output_validator_flags'].split()
         for val in self._actual_validators():
             if val.compile()[0]:
                 feedbackdir = tempfile.mkdtemp(prefix='feedback', dir=self.problem.tmpdir)
@@ -1646,14 +1587,14 @@ class Submissions(ProblemPart):
 
     def full_score_finite(self) -> bool:
         min_score, max_score = self.problem.get(ProblemTestCases)['root_group'].get_score_range()
-        if self.problem.get(ProblemConfig)['grading']['objective'] == 'min':
+        if self.problem.getMetadata().legacy_grading.objective == 'min':
             return min_score != float('-inf')
         else:
             return max_score != float('inf')
 
     def fully_accepted(self, result: SubmissionResult) -> bool:
         min_score, max_score = self.problem.get(ProblemTestCases)['root_group'].get_score_range()
-        best_score = min_score if self.problem.get(ProblemConfig)['grading']['objective'] == 'min' else max_score
+        best_score = min_score if self.problem.getMetadata().legacy_grading.objective == 'min' else max_score
         return result.verdict == 'AC' and (not self.problem.get(ProblemTestCases)['is_scoring'] or result.score == best_score)
 
     def start_background_work(self, context: Context) -> None:
@@ -1669,16 +1610,16 @@ class Submissions(ProblemPart):
             return self._check_res
         self._check_res = True
 
-        limits = self.problem.get(ProblemConfig)['limits']
-        time_multiplier = limits['time_multiplier']
-        safety_margin = limits['time_safety_margin']
+        limits = self.problem.getMetadata().limits
+        time_multiplier = limits.time_multipliers.ac_to_time_limit
+        safety_margin = limits.time_multipliers.time_limit_to_tle
 
         timelim_margin_lo = 300  # 5 minutes
         timelim_margin = 300
         timelim = 300
 
-        if 'time_for_AC_submissions' in limits:
-            timelim = timelim_margin = limits['time_for_AC_submissions']
+        if limits.time_limit is not None:
+            timelim = timelim_margin = int(limits.time_limit) # TODO: Support non-integer time limits
         if context.fixed_timelim is not None:
             timelim = context.fixed_timelim
             timelim_margin = int(round(timelim * safety_margin))
@@ -1695,8 +1636,8 @@ class Submissions(ProblemPart):
                 if context.submission_filter.search(os.path.join(verdict[1], sub_name)):
                     self.info(f'Check {acr} submission {sub}')
 
-                    if sub.code_size() > 1024*limits['code']:
-                        self.error(f'{acr} submission {sub} has size {sub.code_size() / 1024.0:.1f} kiB, exceeds code size limit of {limits["code"]} kiB')
+                    if sub.code_size() > 1024*limits.code:
+                        self.error(f'{acr} submission {sub} has size {sub.code_size() / 1024.0:.1f} kiB, exceeds code size limit of {limits.code} kiB')
                         continue
 
                     success, msg = sub.compile()
@@ -1721,10 +1662,9 @@ class Submissions(ProblemPart):
                 if context.fixed_timelim is not None and context.fixed_timelim != timelim:
                     self.msg(f"   Solutions give timelim of {timelim} seconds, but will use provided fixed limit of {context.fixed_timelim} seconds instead")
                     timelim = context.fixed_timelim
-                    timelim_margin = timelim * safety_margin
+                    timelim_margin = round(timelim * safety_margin) # TODO: properly support 2023-07 time limit computation
 
                 self.msg(f"   Slowest AC runtime: {max_runtime_str}, setting timelim to {timelim} secs, safety margin to {timelim_margin} secs")
-            limits['time'] = timelim
 
         return self._check_res
 
@@ -1738,6 +1678,7 @@ PROBLEM_FORMATS: dict[str, dict[str, list[Type[ProblemPart]]]] = {
         'submissions':  [Submissions],
     },
     formatversion.VERSION_2023_07: { # TODO: Add all the parts
+        'config':       [ProblemConfig],
         'statement':    [ProblemStatement, Attachments],
     }
 }
@@ -1762,6 +1703,7 @@ class Problem(ProblemAspect):
         super().__init__(self.shortname)
         self.language_config = languages.load_language_config()
         self._data: dict[str, dict] = {}
+        self._metadata: metadata.Metadata | None = None
         self.debug(f'Problem-format: {parts}')
 
     def get(self, part) -> dict:
@@ -1769,6 +1711,14 @@ class Problem(ProblemAspect):
             part = part.PART_NAME
         assert part in self._data
         return self._data[part]
+
+    def getMetadata(self) -> metadata.Metadata:
+        assert self._metadata is not None, 'Attempted to access Config before it was set'
+        return self._metadata
+
+    def setMetadata(self, metadata: metadata.Metadata) -> None:
+        assert self._metadata is None, 'Attempted to set Config twice'
+        self._metadata = metadata
 
     def getProblemPart(self, part: Type[_ProblemPartT]) -> _ProblemPartT:
         return self._classes[part.PART_NAME] # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = "MIT"
 dependencies = [
     "PyYAML",
     "plasTeX>=3.0",
+    "pydantic>=2.11",
 ]
 dynamic = [ "version" ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML
 plasTeX>=3.0
+pydantic>=2.11


### PR DESCRIPTION
This PR implements reading 2023-07-draft problem.yaml files.

The main implementation is in the new `problemtools.metadata` module, where I created pydantic models and dataclasses to represent the config file format. For each supported version (2023-07 and legacy), there is a model which should precisely allow what the standard allows. We then convert to a model called `Metadata`, which is a unified format, to allow code later to access metadata in a unified way, regardless of problem format version. The unified format is just a stricter version of 2023-07 with some legacy fields added.

To get type safety in verifyproblem, I added `problem.getMetadata()` to read the metadata, as opposed to re-using the `get()` function, which passes dicts.

I think we should probably take another look at how `Problem` is initialized and how ProblemAspects communicate information between each other. For instance, I would like to make it a fatal error when we fail to parse config.yaml (there really is not much point in proceeding), but I couldn't come up with a clean way to do that in the current structure (and I don't want to mix that refactor into this already large PR).

This PR bumps the python version we require to 3.11, since I wanted to use `StrEnum` to represent e.g. our various license options.