### PR TITLE
Clean-up: Fix everything flagged by `ruff check`, and a few other small fixes

### DIFF
--- a/problemtools/ProblemPlasTeX/ProblemsetMacros.py
+++ b/problemtools/ProblemPlasTeX/ProblemsetMacros.py
@@ -1,12 +1,10 @@
 import sys
 import os
 import os.path
-import io
 from plasTeX.DOM import Node
 from plasTeX.Base import Command
 from plasTeX.Base import DimenCommand
 from plasTeX.Logging import getLogger
-import plasTeX.Packages.graphics as graphics
 
 log = getLogger()
 status = getLogger('status')
@@ -33,7 +31,7 @@ class problemheader(Command):
     args = 'title id:str'
 
     def invoke(self, tex):
-        res = Command.invoke(self, tex)
+        super().invoke(tex)
         timelimfile = os.path.join(os.path.dirname(tex.filename),
                                    '..', '.timelimit')
         if os.path.isfile(timelimfile):
@@ -45,10 +43,10 @@ class sampletable(Command):
     args = 'header1 file1:str header2 file2:str'
 
     def read_sample_file(self, filename):
-        return io.open(filename, 'r', encoding='utf-8').read()
+        return open(filename, 'r', encoding='utf-8').read()
 
     def invoke(self, tex):
-        res = Command.invoke(self, tex)
+        super().invoke(tex)
         dir = os.path.dirname(tex.filename)
         file1 = os.path.join(dir, self.attributes['file1'])
         file2 = os.path.join(dir, self.attributes['file2'])
@@ -67,28 +65,32 @@ class sampletableinteractive(Command):
     args = 'header read write file:str'
 
     def read_sample_interaction(self, filename):
-        data = io.open(filename, 'r', encoding='utf-8').read()
+        data = open(filename, 'r', encoding='utf-8').read()
         messages = []
         cur_msg: list[str] = []
         cur_mode = None
         for line in data.split('\n'):
-            if not line: continue
-            if line[0] == '<': mode = 'read'
-            elif line[0] == '>': mode = 'write'
-            else: continue
+            if not line:
+                continue
+            if line[0] == '<':
+                mode = 'read'
+            elif line[0] == '>':
+                mode = 'write'
+            else:
+                continue
             line = line[1:]
             if mode != cur_mode:
-                if cur_mode: messages.append({'mode': cur_mode,
-                                              'data': '\n'.join(cur_msg)})
+                if cur_mode:
+                    messages.append({'mode': cur_mode, 'data': '\n'.join(cur_msg)})
                 cur_msg = []
             cur_msg.append(line)
             cur_mode = mode
-        if cur_mode: messages.append({'mode': cur_mode,
-                                      'data': '\n'.join(cur_msg)})
+        if cur_mode:
+            messages.append({'mode': cur_mode, 'data': '\n'.join(cur_msg)})
         return messages
 
     def invoke(self, tex):
-        res = Command.invoke(self, tex)
+        super().invoke(tex)
         dir = os.path.dirname(tex.filename)
         file = os.path.join(dir, self.attributes['file'])
         try:
@@ -104,7 +106,7 @@ class sampletableinteractive(Command):
 # \includegraphics implementation)
 class _graphics_command(Command):
     def invoke(self, tex):
-        res = Command.invoke(self, tex)
+        res = super().invoke(tex)
 
         # Overcome plasTeX bug by looking for love in the right place
         basetex = self.ownerDocument.userdata['base_tex_instance']

--- a/problemtools/ProblemPlasTeX/__init__.py
+++ b/problemtools/ProblemPlasTeX/__init__.py
@@ -2,7 +2,6 @@ import re
 import os
 import shutil
 import subprocess
-import plasTeX.Renderers
 from plasTeX.Renderers.PageTemplate import Renderer
 from plasTeX.Filenames import Filenames
 from plasTeX.Imagers import Image
@@ -92,7 +91,7 @@ class ProblemRenderer(Renderer):
             if os.path.isdir(p):
                 templatepath = p
                 break
-        if templatepath == None:
+        if templatepath is None:
             raise Exception('Could not find templates needed for conversion to HTML')
 
         # Ugly but unfortunately PlasTeX is quite inflexible when it comes to

--- a/problemtools/ProblemPlasTeX/listingsutf8.py
+++ b/problemtools/ProblemPlasTeX/listingsutf8.py
@@ -4,8 +4,6 @@ from plasTeX.Logging import getLogger
 import os
 import io
 
-import ProblemsetMacros
-
 log = getLogger()
 
 # Implementation of (parts) of listingsutf8 package since PlasTeX does
@@ -14,13 +12,11 @@ log = getLogger()
 class lstinputlisting(Command):
     args = '* [ options:dict ] file:str'
 
-    def read_file(self, filename):
-        data = io.open(filename, 'r', encoding='utf-8').read()
-        data = ProblemsetMacros.plastex_escape(data)
-        return data
+    def read_file(self, filename) -> str:
+        return io.open(filename, 'r', encoding='utf-8').read()
 
-    def invoke(self, tex):
-        res = Command.invoke(self, tex)
+    def invoke(self, tex) -> None:
+        super().invoke(tex)
         basetex = self.ownerDocument.userdata['base_tex_instance']
         f = self.attributes['file']
         # Maybe more paths to look in?

--- a/problemtools/ProblemPlasTeX/ulem.py
+++ b/problemtools/ProblemPlasTeX/ulem.py
@@ -1,11 +1,29 @@
 from plasTeX.Base.LaTeX.FontSelection import TextCommand
 
-class uline(TextCommand): pass
-class uuline(TextCommand): pass
-class uwave(TextCommand): pass
-class sout(TextCommand): pass
-class xout(TextCommand): pass
-class dashuline(TextCommand): pass
-class dotuline(TextCommand): pass
+
+class uline(TextCommand):
+    pass
 
 
+class uuline(TextCommand):
+    pass
+
+
+class uwave(TextCommand):
+    pass
+
+
+class sout(TextCommand):
+    pass
+
+
+class xout(TextCommand):
+    pass
+
+
+class dashuline(TextCommand):
+    pass
+
+
+class dotuline(TextCommand):
+    pass

--- a/problemtools/generatedata.py
+++ b/problemtools/generatedata.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import glob
 import tempfile
 import shutil
 import yaml

--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -38,13 +38,7 @@ def convert(options: argparse.Namespace) -> None:
 
         # Setup parser and renderer etc
 
-        # plasTeX version 3 changed the name of this argument (and guarding against this
-        # by checking plasTeX.__version__ fails on plastex v3.0 which failed to update
-        # __version__)
-        try:
-            tex = plasTeX.TeX.TeX(myfile=texfile)
-        except Exception:
-            tex = plasTeX.TeX.TeX(file=texfile)
+        tex = plasTeX.TeX.TeX(file=texfile)
 
         ProblemsetMacros.init(tex)
 

--- a/problemtools/run/__init__.py
+++ b/problemtools/run/__init__.py
@@ -6,12 +6,11 @@ import os
 
 from .buildrun import BuildRun
 from .checktestdata import Checktestdata
-from .errors import ProgramError
-from .executable import Executable
+from .errors import ProgramError as ProgramError
 from .program import Program
 from .source import SourceCode
 from .viva import Viva
-from .tools import get_tool_path, get_tool
+from .tools import get_tool as get_tool
 from . import rutil
 
 

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -59,7 +59,6 @@ class Template:
 
         self.templatefile = 'template.tex'
         self.clsfile = 'problemset.cls'
-        timelim = 1  # Legacy for compatibility with v0.1
         version = detect_version(problemdir, problemtex)
         if version != '':
             print('Note: problem is in an old version (%s) of problem format, you should consider updating it' % version)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -22,7 +22,6 @@ import random
 import traceback
 
 import argparse
-import shlex
 
 import yaml
 
@@ -418,7 +417,7 @@ class TestCaseGroup(ProblemAspect):
         # For non-root groups, missing properties are inherited from the parent group
         if parent:
             for field, parent_value in parent.config.items():
-                if not field in self.config:
+                if field not in self.config:
                     self.config[field] = parent_value
 
         # TODO: Decide if these should stay
@@ -498,7 +497,7 @@ class TestCaseGroup(ProblemAspect):
             score_range = self.config['range']
             min_score, max_score = list(map(float, score_range.split()))
             return (min_score, max_score)
-        except:
+        except Exception:
             return (float('-inf'), float('inf'))
 
 
@@ -586,12 +585,14 @@ class TestCaseGroup(ProblemAspect):
         ansfiles = glob.glob(os.path.join(self._datadir, '*.ans'))
 
         for infile in infiles:
-            if os.path.isdir(infile): continue
-            if not f'{infile[:-3]}.ans' in ansfiles:
+            if os.path.isdir(infile):
+                continue
+            if f'{infile[:-3]}.ans' not in ansfiles:
                 self.error(f"No matching answer file for input '{infile}'")
         for ansfile in ansfiles:
-            if os.path.isdir(ansfile): continue
-            if not f'{ansfile[:-4]}.in' in infiles:
+            if os.path.isdir(ansfile):
+                continue
+            if f'{ansfile[:-4]}.in' not in infiles:
                 self.error(f"No matching input file for answer '{ansfile}'")
 
         if not self.get_subgroups() and not self.get_testcases():
@@ -861,7 +862,7 @@ class ProblemConfig(ProblemPart):
             val = self._metadata.legacy_validation.split()
             validation_type = val[0]
             validation_params = val[1:]
-            if not validation_type in ['default', 'custom']:
+            if validation_type not in ['default', 'custom']:
                 self.error(f"Invalid value '{validation_type}' for validation, first word must be 'default' or 'custom'")
 
             if validation_type == 'default' and len(validation_params) > 0:
@@ -873,7 +874,7 @@ class ProblemConfig(ProblemPart):
                         self.error(f"Invalid parameter '{param}' for custom validation")
 
         if self._metadata.limits.time_limit is not None and not self._metadata.limits.time_limit.is_integer():
-            self.warning(f'Time limit configured to non-integer value. Problemtools does not yet support non-integer time limits, and will truncate')
+            self.warning('Time limit configured to non-integer value. Problemtools does not yet support non-integer time limits, and will truncate')
 
         return self._check_res
 
@@ -1323,7 +1324,6 @@ class OutputValidators(ProblemPart):
         validator_args = [testcase.infile, testcase.ansfile, '<feedbackdir>']
         submission_args = submission.get_runcmd(memlim=self.problem.getMetadata().limits.memory)
 
-        val_timelim = self.problem.getMetadata().limits.validation_time
         val_memlim = self.problem.getMetadata().limits.validation_memory
         for val in self._actual_validators():
             if val.compile()[0]:
@@ -1914,7 +1914,8 @@ def main() -> None:
             format = PROBLEM_FORMATS[version_data.name]
             with Problem(problemdir, format) as prob:
                 errors, warnings = prob.check(args)
-                p = lambda x: '' if x == 1 else 's'
+                def p(x: int) -> str:
+                    return '' if x == 1 else 's'
                 print(f'{prob.shortname} tested: {errors} error{p(errors)}, {warnings} warning{p(warnings)}')
                 total_errors += errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,10 @@ include = ["problemtools", "problemtools.*"]
 
 [tool.setuptools_scm]
 version_file = "problemtools/_version.py"
+
+[tool.ruff]
+line-length = 130
+exclude = [ "examples" ]
+
+[tool.ruff.format]
+quote-style = "single"

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -19,7 +19,7 @@ class Language_test(TestCase):
                 }
 
     def test_create(self):
-        lang = languages.Language('langid', self.__language_dict())
+        languages.Language('langid', self.__language_dict())
 
     def test_update(self):
         lang = languages.Language('langid', self.__language_dict())

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -15,7 +15,7 @@ def test_parse_empty_legacy():
 
 def test_parse_empty_2023_fails():
     with pytest.raises(ValidationError):
-        m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), {}, {'en': 'Hello World!'})
+        metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), {}, {'en': 'Hello World!'})
 
 @pytest.fixture
 def minimal_2023_conf():
@@ -35,7 +35,7 @@ def test_parse_typo_fails(minimal_2023_conf):
     c = minimal_2023_conf
     c['limits'] = { 'typo': 1 }
     with pytest.raises(ValidationError):
-        m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), c, {'en': 'Hello World!'})
+        metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_2023_07), c, {'en': 'Hello World!'})
 
 def test_parse_single_author_2023(minimal_2023_conf):
     c = minimal_2023_conf


### PR DESCRIPTION
This PR adds a `ruff` configuration, and fixes everything flagged by a run of `ruff check`. I also cleaned up a few small things I spotted while fixing the things `ruff` flagged.

Fixes problem statement rendering being broken if `listingsutf8` was used in the tex file.

Makes a minor modification of what is exported from `problemtools.run`. I doubt anyone is using that module as an API (but please do let me know if that's the case).

Progress on #249