### PR TITLE
Run all of verifyproblem for 2023-07 problems (even if we do not support many 2023-07 features)

### DIFF
--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -19,11 +19,22 @@ class FormatData:
     name: str
     statement_directory: str
     statement_extensions: list[str]
+    output_validator_directory: str
 
 
 FORMAT_DATACLASSES = {
-    VERSION_LEGACY: FormatData(name=VERSION_LEGACY, statement_directory='problem_statement', statement_extensions=['tex']),
-    VERSION_2023_07: FormatData(name=VERSION_2023_07, statement_directory='statement', statement_extensions=['md', 'tex']),
+    VERSION_LEGACY: FormatData(
+        name=VERSION_LEGACY,
+        statement_directory='problem_statement',
+        statement_extensions=['tex'],
+        output_validator_directory='output_validators',
+    ),
+    VERSION_2023_07: FormatData(
+        name=VERSION_2023_07,
+        statement_directory='statement',
+        statement_extensions=['md', 'tex'],
+        output_validator_directory='output_validator',
+    ),
 }
 FORMAT_DATACLASSES['2023-07'] = FORMAT_DATACLASSES[VERSION_2023_07]  # Accept non-draft version string too
 

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -854,7 +854,7 @@ class ProblemConfig(ProblemPart):
             self.problem.setMetadata(self._metadata)
         except ValidationError as e:
             # This should likely be a fatal error, but I'm not sure there's a clean way to fail from setup
-            error_str = '\n'.join([f'    {"->".join(str(err["loc"]))}: {err["msg"]}' for err in e.errors()])
+            error_str = '\n'.join([f'    {"->".join((str(loc) for loc in err["loc"]))}: {err["msg"]}' for err in e.errors()])
             self.error(f'Failed parsing problem.yaml. Found {len(e.errors())} errors:\n{error_str}')
         return {}
 

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1234,7 +1234,7 @@ class OutputValidators(ProblemPart):
 
     def setup(self):
         self._validators = run.find_programs(
-            os.path.join(self.problem.probdir, 'output_validators'),
+            os.path.join(self.problem.probdir, self.problem.format.output_validator_directory),
             language_config=self.problem.language_config,
             work_dir=self.problem.tmpdir,
         )
@@ -1263,7 +1263,7 @@ class OutputValidators(ProblemPart):
 
         if self.problem.getMetadata().legacy_validation == 'default' and self._validators:
             self.error('There are validator programs but problem.yaml has validation = "default"')
-        elif self.problem.getMetadata().legacy_validation != 'default' and not self._validators:
+        elif self.problem.getMetadata().legacy_validation.startswith('custom') and not self._validators:
             self.error('problem.yaml specifies custom validator but no validator programs found')
 
         if self.problem.getMetadata().legacy_validation == 'default' and self._default_validator is None:
@@ -1360,7 +1360,9 @@ class OutputValidators(ProblemPart):
 
     def _actual_validators(self) -> list:
         vals = self._validators
-        if self.problem.getMetadata().legacy_validation == 'default':
+        if self.problem.getMetadata().legacy_validation == 'default' or (
+            self.problem.format.name == formatversion.VERSION_2023_07 and not vals
+        ):
             vals = [self._default_validator]
         return [val for val in vals if val is not None]
 
@@ -1759,6 +1761,10 @@ PROBLEM_FORMATS: dict[str, dict[str, list[Type[ProblemPart]]]] = {
     formatversion.VERSION_2023_07: {  # TODO: Add all the parts
         'config': [ProblemConfig],
         'statement': [ProblemStatement, Attachments],
+        'validators': [InputValidators, OutputValidators],
+        'graders': [Graders],
+        'data': [ProblemTestCases],
+        'submissions': [Submissions],
     },
 }
 


### PR DESCRIPTION
Now runs through all of verifyproblem for 2023-07 problems. Most parts have not been updated to follow the standard yet, but I felt we're at a stage where it makes more sense to just try to do validation rather than exit after verifying just the config. I did quick testing locally with `hello` and `different` by just updating `problem.yaml` and renaming `output_validators` and `problem_statements`, and those now pass successfully. I'm unsure if they are actually valid 2023-07 packages with just those simple fixes.

Adds a warning about 2023-07 support being incomplete.

Also a bugfix where I'd messed up our formatting of pydantic errors, giving very ugly messages on problem.yaml errors.