### PR TITLE
Suggest a new UUID when missing from config

### DIFF
--- a/problemtools/metadata.py
+++ b/problemtools/metadata.py
@@ -113,7 +113,7 @@ class Metadata2023_07(BaseModel):
 
     problem_format_version: str
     name: dict[str, str] | str
-    uuid: UUID
+    uuid: UUID | None = None  # UUID *is* mandatory, but we deal with that in verifyproblem for better UX
     type: list[ProblemType] | ProblemType = ProblemType.PASS_FAIL
     version: str | None = None
     credits: dict | str | None = None

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import argparse
 import concurrent.futures
 from concurrent.futures import ThreadPoolExecutor
 import threading
@@ -20,8 +21,7 @@ import sys
 import copy
 import random
 import traceback
-
-import argparse
+import uuid
 
 import yaml
 
@@ -874,6 +874,13 @@ class ProblemConfig(ProblemPart):
         # Check license
         if self._metadata.license == metadata.License.UNKNOWN:
             self.warning("License is 'unknown'")
+
+        if self._metadata.uuid is None:
+            uuid_msg = f'Missing uuid from problem.yaml. Add "uuid: {uuid.uuid4()}" to problem.yaml.'
+            if self.problem.format.name == formatversion.VERSION_LEGACY:
+                self.warning(uuid_msg)
+            else:
+                self.error(uuid_msg)
 
         if self._metadata.legacy_grading.show_test_data_groups and self._metadata.is_pass_fail():
             self.error('Showing test data groups is only supported for scoring problems, this is a pass-fail problem')


### PR DESCRIPTION
Earlier verification was a bit too harsh when UUID is missing, stopping further validation. This PR softens it, and makes a missing UUID a warning or error (depending on problem format), and helpfully suggests a random UUID for you to put in problem.yaml.