### PR TITLE
Refactor metadata loading

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,6 +29,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install mypy ruff pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        sudo apt-get update
         sudo apt-get install pandoc tidy ghostscript python3 texlive-fonts-recommended texlive-lang-cyrillic texlive-latex-extra texlive-plain-generic
     - name: Lint with ruff
       run: ruff check --output-format=github
@@ -45,7 +46,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install apt packages (for debbuild)
-      run: sudo apt-get install debhelper dh-virtualenv dpkg-dev python3-venv automake g++ make libboost-regex-dev libgmp-dev python3 git build-essential
+      run: |
+        sudo apt-get update
+        sudo apt-get install debhelper dh-virtualenv dpkg-dev python3-venv automake g++ make libboost-regex-dev libgmp-dev python3 git build-essential
       shell: bash
     - name: Build debian packages
       run:  make builddeb

--- a/problemtools/metadata.py
+++ b/problemtools/metadata.py
@@ -224,7 +224,12 @@ class Metadata(BaseModel):
         metadata = legacy.model_dump()
         metadata['type'] = [metadata['type']]
         # Support for *ancient* problems where names_from_statements is empty
-        metadata['name'] = names_from_statements if names_from_statements else {'': metadata['name']}
+        if names_from_statements:
+            metadata['name'] = names_from_statements
+        elif metadata['name']:
+            metadata['name'] = {'': metadata['name']}
+        else:
+            metadata['name'] = {}
         metadata['version'] = None
 
         def parse_author_field(author: str) -> list[Person]:

--- a/problemtools/statement_util.py
+++ b/problemtools/statement_util.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Optional, List, Tuple
 
 from . import formatversion
-from . import verifyproblem
+from . import metadata
 
 ALLOWED_IMAGE_EXTENSIONS = ('.png', '.jpg', '.jpeg')  # ".svg"
 FOOTNOTES_STRINGS = ['<section class="footnotes">', '<aside class="footnotes">']
@@ -91,13 +91,8 @@ def find_statement_extension(problem_root: str, language: Optional[str]) -> str:
 def get_yaml_problem_name(problem: str, language: Optional[str]) -> str:
     """Finds the problem name from the problem.yaml file"""
 
-    # Minimal setup to get the problem name
-    problem_obj = verifyproblem.Problem(problem)
-    statement_obj = verifyproblem.ProblemStatement(problem_obj)
-    problem_obj._data[statement_obj.PART_NAME] = statement_obj.setup()
-    verifyproblem.ProblemConfig(problem_obj).setup()
-
-    names = problem_obj.getMetadata().name
+    problem_metadata, _ = metadata.load_metadata(Path(problem))
+    names = problem_metadata.name
     # If there is only one language, per the spec that is the one we want
     if len(names) == 1:
         return next(iter(names.values()))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -8,11 +8,16 @@ from problemtools import formatversion, metadata
 
 
 def test_parse_empty_legacy():
-    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_LEGACY), {}, {'en': 'Hello World!'})
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_LEGACY), {}, {})
     # Just check off a few random things
-    assert m.name['en'] == 'Hello World!'
+    assert not m.name
     assert not m.source
     assert not m.credits.authors
+
+
+def test_parse_legacy_with_problem_names():
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_LEGACY), {}, {'en': 'Hello World!'})
+    assert m.name['en'] == 'Hello World!'
 
 
 def test_parse_empty_2023_fails():

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from pathlib import Path
+
 import pytest
 
 from pydantic import ValidationError
@@ -8,7 +10,7 @@ from problemtools import formatversion, metadata
 
 
 def test_parse_empty_legacy():
-    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_LEGACY), {}, {})
+    m = metadata.parse_metadata(formatversion.get_format_data_by_name(formatversion.VERSION_LEGACY), {})
     # Just check off a few random things
     assert not m.name
     assert not m.source
@@ -83,3 +85,18 @@ def test_parse_multi_source(minimal_2023_conf):
     assert m.source[1].url is None
     assert m.source[2].name == 'SEERC 2024'
     assert m.source[2].url is None
+
+
+def test_load_hello():
+    m, _ = metadata.load_metadata(Path(__file__).parent / 'hello')
+    assert m.name['en'] == 'Hello World!'
+    assert m.name['sv'] == 'Hej Världen!'
+    assert len(m.source) == 1
+    assert m.source[0].name == 'Kattis'
+    assert m.source[0].url is None
+    assert m.license is metadata.License.PUBLIC_DOMAIN
+    assert len(m.type) == 1
+    assert m.type[0] is metadata.ProblemType.PASS_FAIL
+    assert m.is_pass_fail()
+    assert not m.is_scoring()
+    assert not m.is_interactive()


### PR DESCRIPTION
Add a new interface to `metadata`, `load_metadata` which deals with the need to rummage through problem statements in search for problem names in the legacy format.

Add two new methods to `statement_util` to find statements and extract problem names. I intend to use these to replace our code scanning for statements in `statement_util.py` (used by `problem2*`), `verifyproblem.py`, and `template.py` to unify that code. I opted to keep that for a separate PR to keep the size of each PR reasonable.

This PR also adds an `apt-get update` step to our CI scripts, as CI had broken when ubuntu released newer packages than the docker image we ran on knew about.