### PR TITLE
Restructure setup error handling

### DIFF
--- a/tests/test_verify_hello.py
+++ b/tests/test_verify_hello.py
@@ -10,7 +10,7 @@ def test_load_hello():
     verify.initialize_logging(args)
     context = verify.Context(args, None)
 
-    with verify.Problem(string) as p:
+    with verify.Problem(string, args) as p:
         assert p.shortname == 'hello'
         # pytest and fork don't go along very well, so just run aspects that work without run
         assert p.getProblemPart(verify.ProblemConfig).check(context)

--- a/tests/test_verify_hello.py
+++ b/tests/test_verify_hello.py
@@ -11,6 +11,7 @@ def test_load_hello():
     context = verify.Context(args, None)
 
     with verify.Problem(string, args) as p:
+        p.load()
         assert p.shortname == 'hello'
         # pytest and fork don't go along very well, so just run aspects that work without run
         assert p.getProblemPart(verify.ProblemConfig).check(context)


### PR DESCRIPTION
Restructures error handling, getting rid of the weird structure where we used class variables in `ProblemAspect` to keep track of the number of errors encountered. This also fixed bugs with error counts, where errors occuring in `setup()` were not included in error counts after `check()` had been called, and where --werror and --bail_on_error didn't work on errors in `setup()`. I feel like further refactoring of setup and component interaction is needed, but I didn't want to blow up this PR.

Adds fatal errors, where the error is severe enough that it makes more sense to stop validation than to proceed. This happens when we fail to parse config, or when graders/output validators are missing or fail to compile (when it feels better to just stop instead of burning CPU for submissions just to get judge error).

Also adds a check of all file and directory names in the package, per https://www.kattis.com/problem-package-format/spec/2023-07-draft.html#general-requirements . There are no requirements on directory names in `legacy`, but I made it a warning if directory names in a legacy package do not comply with 2023-07.