### PR TITLE
Improved checks for types, interaction samples, and output validator language

### DIFF
--- a/problemtools/metadata.py
+++ b/problemtools/metadata.py
@@ -222,6 +222,12 @@ class Metadata(BaseModel):
     def is_interactive(self) -> bool:
         return ProblemType.INTERACTIVE in self.type
 
+    def is_multi_pass(self) -> bool:
+        return ProblemType.MULTI_PASS in self.type
+
+    def is_submit_answer(self) -> bool:
+        return ProblemType.SUBMIT_ANSWER in self.type
+
     @classmethod
     def from_legacy(cls: Type[Self], legacy: MetadataLegacy, names_from_statements: dict[str, str]) -> Self:
         metadata = legacy.model_dump()

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1226,11 +1226,13 @@ class OutputValidators(ProblemPart):
 
         self.warn_directory('output validators', 'output_validator_directory')
 
-        recommended_output_validator_languages = {'c', 'cpp', 'python3'}
+        safe_output_validator_languages = {'c', 'cpp', 'python3'}
 
         for v in self._validators:
-            if isinstance(v, run.SourceCode) and v.language.lang_id not in recommended_output_validator_languages:
-                self.warning('output validator language %s is not recommended' % v.language.name)
+            if isinstance(v, run.SourceCode) and v.language.lang_id not in safe_output_validator_languages:
+                self.error_in_2023_07(
+                    f'Output validator in {v.language.name}. Only {safe_output_validator_languages} are standardized. Check carefully if your CCS supports more (Kattis does not).'
+                )
 
         if self.problem.metadata.legacy_validation == 'default' and self._validators:
             self.error('There are validator programs but problem.yaml has validation = "default"')

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -828,6 +828,20 @@ class ProblemConfig(ProblemPart):
             return self._check_res
         self._check_res = True
 
+        INCOMPATIBLE_TYPES = [
+            (metadata.ProblemType.PASS_FAIL, metadata.ProblemType.SCORING),
+            (metadata.ProblemType.SUBMIT_ANSWER, metadata.ProblemType.MULTI_PASS),
+            (metadata.ProblemType.SUBMIT_ANSWER, metadata.ProblemType.INTERACTIVE),
+        ]
+        for t1, t2 in INCOMPATIBLE_TYPES:
+            if t1 in self._metadata.type and t2 in self._metadata.type:
+                self.error(f'Problem has incompatible types: {t1}, {t2}')
+
+        if metadata.ProblemType.MULTI_PASS in self._metadata.type:
+            self.warning('The type multi-pass is not yet supported.')
+        if metadata.ProblemType.SUBMIT_ANSWER in self._metadata.type:
+            self.warning('The type submit-answer is not yet supported.')
+
         # Check rights_owner
         if self._metadata.license == metadata.License.PUBLIC_DOMAIN:
             if self._metadata.rights_owner:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -86,6 +86,21 @@ def test_parse_multi_source(minimal_2023_conf):
     assert m.source[2].url is None
 
 
+def test_parse_complex_type(minimal_2023_conf):
+    c = minimal_2023_conf
+    c['type'] = ['scoring', 'multi-pass', 'interactive']
+    m = metadata.parse_metadata(FormatVersion.V_2023_07, c, {'en': 'Hello World!'})
+    assert len(m.type) == 3
+    assert metadata.ProblemType.SCORING in m.type
+    assert metadata.ProblemType.MULTI_PASS in m.type
+    assert metadata.ProblemType.INTERACTIVE in m.type
+    assert not m.is_pass_fail()
+    assert m.is_scoring()
+    assert m.is_interactive()
+    assert m.is_multi_pass()
+    assert not m.is_submit_answer()
+
+
 def test_load_hello():
     m, _ = metadata.load_metadata(Path(__file__).parent / 'hello')
     assert m.name['en'] == 'Hello World!'
@@ -99,3 +114,5 @@ def test_load_hello():
     assert m.is_pass_fail()
     assert not m.is_scoring()
     assert not m.is_interactive()
+    assert not m.is_multi_pass()
+    assert not m.is_submit_answer()

--- a/tests/test_verify_hello.py
+++ b/tests/test_verify_hello.py
@@ -16,3 +16,8 @@ def test_load_hello():
         # pytest and fork don't go along very well, so just run aspects that work without run
         assert p.config.check(context)
         assert p.attachments.check(context)
+        assert p.is_pass_fail()
+        assert not p.is_scoring()
+        assert not p.is_interactive()
+        assert not p.is_multi_pass()
+        assert not p.is_submit_answer()


### PR DESCRIPTION
Adds checks for incompatible problem types (e.g., combining pass-fail and scoring).
Adds warnings for types we do not yet support (multi-pass, submit-answer).
Checks format of interaction files (each line starts with < or >)
Adds convenience methods on `Problem` for `is_{pass_fail, scoring, ...}` as it felt clumsy to go via metadata.

Fixes #258 
Fixes #277 