### PR TITLE
Fix docker build

### DIFF
--- a/admin/docker/Dockerfile.build
+++ b/admin/docker/Dockerfile.build
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Packages required to build and run problemtools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update && apt-get install -y \
         automake \
         build-essential \

--- a/admin/docker/Dockerfile.fulllangs
+++ b/admin/docker/Dockerfile.fulllangs
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # All languages, plus curl which we need to fetch pypy2
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update && apt-get install -y \
         curl \
         fp-compiler \

--- a/admin/docker/Dockerfile.githubci
+++ b/admin/docker/Dockerfile.githubci
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Packages required to build and run problemtools
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update && apt-get install -y \
         automake \
         build-essential \

--- a/admin/docker/Dockerfile.icpclangs
+++ b/admin/docker/Dockerfile.icpclangs
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update && apt-get install -y \
         gcc \
         g++ \

--- a/admin/docker/Dockerfile.runreqs
+++ b/admin/docker/Dockerfile.runreqs
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # (and we need libgmp-dev in other images), we take libgmp-dev here
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    rm -f /etc/apt/apt.conf.d/docker-clean \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
     apt-get update && apt-get install -y \
         dvisvgm \
         ghostscript \

--- a/admin/update_docker.sh
+++ b/admin/update_docker.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 set -e
 
+ALLOW_DIRTY=false
 TAG=develop
 UPDATE_LATEST=false
+
+while getopts "d" opt; do
+    case $opt in
+        d) ALLOW_DIRTY=true ;;
+        \?) echo "Invalid option: -$opt" ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
 if [ "$1" != "" ]; then
     TAG=$1
     UPDATE_LATEST=true
@@ -13,12 +24,12 @@ cd $(dirname $(readlink -f $0))/docker
 if [[ -n $(git status -s) ]]; then
     echo "Repository is dirty."
     git status -s
-    exit 1
+    [[ "${ALLOW_DIRTY}" != "true" ]] && exit 1
 fi
 
 if [[ $(git rev-parse --abbrev-ref HEAD) != ${TAG} && $(git describe --exact-match --tags 2>/dev/null) != ${TAG} ]]; then
     echo "Repository is currently not on branch/tag ${TAG}."
-    exit 1
+    [[ "${ALLOW_DIRTY}" != "true" ]] && exit 1
 fi
 
 

--- a/admin/update_docker.sh
+++ b/admin/update_docker.sh
@@ -49,7 +49,7 @@ mkdir -p artifacts
 sudo rm -rf artifacts/deb
 # Use our build image to build a deb
 docker run --rm -v "$(pwd)/../..:/problemtools" -v "$(pwd)/artifacts/deb:/artifacts" problemtools/build:${TAG} \
-    /bin/bash -c '
+    /bin/bash -c "
         set -e ;
         mkdir /build ;
         cd /build ;
@@ -57,7 +57,7 @@ docker run --rm -v "$(pwd)/../..:/problemtools" -v "$(pwd)/artifacts/deb:/artifa
         git clone --branch ${TAG} /problemtools ;
         cd problemtools ;
         make builddeb ;
-        cp ../*.deb /artifacts'
+        cp ../*.deb /artifacts"
 sudo chown -R $USER:$USER artifacts/
 
 


### PR DESCRIPTION
I had apparently been a bit sloppy in properly testing docker building, `update_docker.sh` failed on `git clone` as I'd changed `'` to `"` between testing and committing.

- Fixes silly error in docker files, where we due to a missing `&&` attempted to delete the files `apt-get` and `update` instead of running the command. :)
- Adds a `-d` option to `update_docker.sh` which allows the repository to be dirty, simplifying testing one more time before commit:ing.