### PR TITLE
A few small fixes / extra checks

### DIFF
--- a/admin/docker/Dockerfile.full
+++ b/admin/docker/Dockerfile.full
@@ -10,7 +10,7 @@
 #    PROBLEMTOOLS_VERSION but this is not checked.)
 
 ARG PROBLEMTOOLS_VERSION=develop
-FROM problemtools/runreqs:${PROBLEMTOOLS_VERSION}
+FROM problemtools/fulllangs:${PROBLEMTOOLS_VERSION}
 
 LABEL maintainer="contact@kattis.com"
 ENV DEBIAN_FRONTEND=noninteractive

--- a/problemtools/ProblemPlasTeX/ProblemsetMacros.py
+++ b/problemtools/ProblemPlasTeX/ProblemsetMacros.py
@@ -114,7 +114,7 @@ class _graphics_command(Command):
         f = self.attributes['file']
         ext = self.ownerDocument.userdata.getPath('packages/graphicx/extensions', ['.png', '.jpg', '.jpeg', '.gif', '.pdf'])
         paths = self.ownerDocument.userdata.getPath('packages/graphicx/paths', [os.path.dirname(basetex.filename)])
-        img = None
+        img: str | None = None
         # Check for file using graphicspath
         for p in paths:
             for e in [''] + ext:
@@ -134,7 +134,7 @@ class _graphics_command(Command):
                 except (OSError, IOError):
                     pass
 
-        if not os.path.isfile(img):
+        if img is None or not os.path.isfile(img):
             log.warning('Could not identify image "%s"' % f)
 
         self.imageoverride = img

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1214,6 +1214,11 @@ class OutputValidators(ProblemPart):
         )
         self._has_precompiled = False
 
+    def uses_default_validator(self) -> bool:
+        if self.problem.format is FormatVersion.LEGACY:
+            return self.problem.metadata.legacy_validation == 'default'
+        return not self._validators
+
     def __str__(self) -> str:
         return 'output validators'
 
@@ -1238,12 +1243,15 @@ class OutputValidators(ProblemPart):
                     f'Output validator in {v.language.name}. Only {safe_output_validator_languages} are standardized. Check carefully if your CCS supports more (Kattis does not).'
                 )
 
-        if self.problem.metadata.legacy_validation == 'default' and self._validators:
+        if len(self._validators) > 1:
+            self.error_in_2023_07('Found more than one output validator. This was allowed in legacy (but not on Kattis)')
+
+        if self.uses_default_validator() and self._validators:
             self.error('There are validator programs but problem.yaml has validation = "default"')
-        elif self.problem.metadata.legacy_validation.startswith('custom') and not self._validators:
+        elif not self.uses_default_validator() and not self._validators:
             self.fatal('problem.yaml specifies custom validator but no validator programs found')
 
-        if self.problem.metadata.legacy_validation == 'default' and self._default_validator is None:
+        if self.uses_default_validator() and self._default_validator is None:
             self.fatal('Unable to locate default validator')
 
         for val in self._validators[:]:
@@ -1336,10 +1344,9 @@ class OutputValidators(ProblemPart):
         return SubmissionResult('AC', score=score)
 
     def _actual_validators(self) -> list:
-        vals = self._validators
-        if self.problem.metadata.legacy_validation == 'default' or (self.problem.format is FormatVersion.V_2023_07 and not vals):
-            vals = [self._default_validator]
-        return [val for val in vals if val is not None]
+        if self.uses_default_validator():
+            return [self._default_validator]
+        return self._validators
 
     def validate_interactive(self, testcase: TestCase, submission, timelim: int, errorhandler: Submissions) -> SubmissionResult:
         # This may be called off-main thread.
@@ -1405,7 +1412,6 @@ class OutputValidators(ProblemPart):
                 shutil.rmtree(feedbackdir)
                 if res.verdict != 'AC':
                     return res
-        # TODO: check that all output validators give same result
         return res
 
     def validate(self, testcase: TestCase, submission_output: str) -> SubmissionResult:

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -867,6 +867,10 @@ class ProblemConfig(ProblemPart):
         if self._metadata.uuid is None:
             self.error_in_2023_07(f'Missing uuid from problem.yaml. Add "uuid: {uuid.uuid4()}" to problem.yaml.')
 
+        names_with_no_statement = [lang for lang in self._metadata.name if lang not in self.problem.statement.statements]
+        if names_with_no_statement:
+            self.error(f'Names exist for languages without problem statements: {", ".join(names_with_no_statement)}')
+
         if self._metadata.legacy_grading.show_test_data_groups and self.problem.is_pass_fail():
             self.error('Showing test data groups is only supported for scoring problems, this is a pass-fail problem')
         if (

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1800,6 +1800,7 @@ class Problem(ProblemAspect):
         self.graders = Graders(self)
         self.testdata = TestCaseGroup(self, os.path.join(self.probdir, 'data'))
         self.submissions = Submissions(self)
+        self.loaded = True
 
     def __enter__(self) -> Problem:
         self.tmpdir = tempfile.mkdtemp(prefix=f'verify-{self.shortname}-')

--- a/tests/test_verify_hello.py
+++ b/tests/test_verify_hello.py
@@ -21,3 +21,13 @@ def test_load_hello():
         assert not p.is_interactive()
         assert not p.is_multi_pass()
         assert not p.is_submit_answer()
+
+
+def test_load_twice():
+    directory = pathlib.Path(__file__).parent / 'hello'
+    string = str(directory.resolve())
+
+    args = verify.argparser().parse_args([string])
+    with verify.Problem(string, args) as p:
+        p.load()
+        p.load()


### PR DESCRIPTION
A small PR gathering up a few fixes/improvements:

- Fixes a crash if one did `load`/`check` twice (and adds a test case)
- Adds error if there are problem names configured without matching statements
- Adds a function to check if validation uses the default validator (and simplify a bit of code using it)
- Adds a warning/error if there are multiple output validators
- Adds support for `-i` in `md2html` (setting a base URL for all image paths in the html)
- Fix dockerfile for `full` missing a lot of languages