### PR TITLE
Fix version computation when we build pypi packages

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -19,6 +19,7 @@ jobs:
       image: quay.io/pypa/manylinux_2_28_x86_64
     steps:
     - uses: actions/checkout@v4
+      fetch-depth: 0  # We need full history for setuptools_scm to figure out version
     - name: Set safe directory (work around checkout not doing that properly for containers)
       run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Install build dependencies for checktestdata


### PR DESCRIPTION
This should hopefully fix the version ending up as 0.1.dev1 when using the pypi workflow.

Progress on #322 