### PR TITLE
Prepare for release 1.20250605 and for moving development from `devel` to `master`

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2010-2019 Kattis and all respective contributors
+Copyright (c) Kattis and all respective contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Kattis Problem Tools
 
-master:
-![Master Build Status](https://github.com/kattis/problemtools/actions/workflows/python-app.yml/badge.svg?branch=master)
-develop:
-![Develop Build Status](https://github.com/kattis/problemtools/actions/workflows/python-app.yml/badge.svg?branch=develop)
+![Build Status](https://github.com/kattis/problemtools/actions/workflows/python-app.yml/badge.svg?branch=master)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
-These are tools to manage problem packages using the Kattis problem package
-format.
+These are tools to manage problem packages using the Kattis [problem package
+format](https://www.kattis.com/problem-package-format/). The problem package
+specification is developed in the [problem package format
+repository](https://github.com/Kattis/problem-package-format).
 
 
 ## Programs Provided
@@ -47,11 +47,15 @@ A few examples of problem packages can be found in [examples](examples).
 There are four supported ways of installing and running problemtools.
 (For non-Linux users, "Method 2" below, to use Docker, is probably the least painful.)
 
+Note that in all methods except for "Method 2", you must manually install
+dependencies such as LaTeX and tools for any languages you want to use. See
+[Requirements and compatbility](#requirements-and-compatibility) for details.
+
 ### Method 1: Install the Python package using pipx
 
 Run
 ```
-pipx install git+https://github.com/kattis/problemtools
+pipx install problemtools
 ```
 
 In order to get the command line scripts, you need to make sure that the local
@@ -77,19 +81,30 @@ We maintain three official problemtools Docker images on Docker Hub:
 
 - [`problemtools/minimal`](https://hub.docker.com/r/problemtools/minimal/): this image only contains problemtools, no additional programming languages.  As such, it is not particularly useful on its own, but if you are organizing a contest and want to set up a problemtools environment containing exactly the right set of compilers/interpreters for your contest, this is the recommended starting point.
 
-For example, suppose you want to use the `problemtools/icpc` image.  To get started, install the [Docker CLI](https://docs.docker.com/install), and then pull the image:
+For example, suppose you want to use the `problemtools/icpc` image.  To get started (or update to the latest release), install the [Docker CLI](https://docs.docker.com/install), and then pull the image:
 
     docker pull problemtools/icpc
 
-Once the image has finished downloading, you can check that it exists on your system using `docker images`. To launch an interactive container and play around with *verifyproblem*, *problem2pdf*, and *problem2html* run:
+The most convenient way to use the container is by creating shell script(s) similar to this and add it to your `$PATH`. If you call the script `verifyproblem.sh`, you could then `verifyproblem.sh examples/hello` to use the icpc docker image to verify examples/hello:
+```sh
+#!/bin/bash
+
+if [ $1 -a -d $1 ]; then
+    docker run --rm -t -v $(dirname $(readlink -f $1)):/work problemtools/icpc verifyproblem /work/$(basename $1)
+else
+    echo No such directory: $1
+fi
+```
+
+To instead launch an interactive container and play around with *verifyproblem*, *problem2pdf*, and *problem2html* run:
 
     docker run --rm -it problemtools/icpc
 
 By default, docker containers do _NOT_ persist storage between runs, so any files you create or modify will be lost when the container stops running.  Two common ways of dealing with this are:
 
-1) Use a [bind mount](https://docs.docker.com/storage/bind-mounts/) to mount a directory on your machine into the docker container.  This can be done as follows (see Docker documentation for further details):
+1) Use a [bind mount](https://docs.docker.com/storage/bind-mounts/) to mount a directory on your machine into the docker container.  Mounting the current directory to /kattis_work_dir can be done as follows (see Docker documentation for further details):
     ```
-    docker run --rm -it -v ${FULL_PATH_TO_MOUNT}:/kattis_work_dir problemtools/icpc
+    docker run --rm -it -v $(pwd):/kattis_work_dir problemtools/icpc
     ```
 2) Persist any changes you want to keep to a remote file system/source control (e.g., a remote Git repository; note, however, that you would first need to install Git in the image).
 
@@ -211,7 +226,8 @@ problemtools' configuration:
 ## Requirements and compatibility
 
 To build and run the tools, you need Python 3 with the YAML and PlasTeX libraries,
-and a LaTeX installation.
+and a LaTeX installation. You must also install language tools (e.g., compilers)
+for any languages used in problem packages.
 
 ### Ubuntu
 

--- a/admin/build_pypi_packages.sh
+++ b/admin/build_pypi_packages.sh
@@ -4,6 +4,10 @@ set -e
 ALLOW_DIRTY=false
 TAG=develop
 
+echo N.B., this script is solely to allow for local testing of whl/src.
+echo To actually build and push things to pypi, trigger the pypi flow
+echo in github actions, https://github.com/Kattis/problemtools/actions
+
 while getopts "d" opt; do
     case $opt in
         d) ALLOW_DIRTY=true ;;

--- a/admin/make_release.sh
+++ b/admin/make_release.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 #
-# Uses git flow and gbp tools (available through Ubuntu packages
-# git-flow, git-buildpackage)
+# Uses gbp (available through Ubuntu package git-buildpackage)
 
 set -e
+
+ALLOW_DIRTY=false
+while getopts "d" opt; do
+    case $opt in
+        d) ALLOW_DIRTY=true ;;
+        \?) echo "Invalid option: -$opt" ;;
+    esac
+done
 
 ROOT=$(readlink -f $(dirname $0)/..)
 VERSION=1.$(date +%Y%m%d)
@@ -16,20 +23,50 @@ if [ "$(git tag -l v$VERSION)" != "" ]; then
     VERSION=$VERSION-rev$REV
 fi
 
-set -x
 
-git flow release start --showcommands $VERSION
+# Steps:
+#   Pick a version (done by the above loop)
+#   Update debian/changelog using gbp
+#   Create and merge pull request with the updated debian/changelog
+#   Create a github release (using web UI) or gh
+#   Push to pypi using github action
+#   Push to docker using admin/update_docker.sh v$VERSION
 
-# Update _version.py
-$ROOT/admin/update_version.py.sh $VERSION
+CHANGELOG_VERSION=$(dpkg-parsechangelog -l $ROOT/debian/changelog --show-field Version)
+if [[ $CHANGELOG_VERSION == $VERSION ]]; then
+    echo "Debian changelog seems updated"
+else
+    echo "Updating debian changelog (this is surprisingly slow)"
+    EMAIL=$(git config user.email) gbp dch $ROOT --release --new-version=$VERSION --ignore-branch --git-author --debian-tag='v%(version)s' --debian-branch=release/$VERSION --spawn-editor=never
+    echo "Please commit the updated changelog, do a pull request, and get it merged, then run this script again on an up-to-date master branch"
+    exit 0
+fi
 
-# Update debian/changelog
-gbp dch $ROOT --release --new-version=$VERSION --git-author --debian-tag='v%(version)s' --debian-branch=release/$VERSION --spawn-editor=never
+cd $(dirname $(readlink -f $0))
 
-git add $ROOT/problemtools/_version.py $ROOT/debian/changelog
-git commit -m "Release of version $VERSION: bump version in problemtools/_version.py and debian/changelog"
+if [[ -n $(git status -s) ]]; then
+    echo "Repository is dirty."
+    git status -s
+    [[ "${ALLOW_DIRTY}" != "true" ]] && exit 1
+fi
 
-git flow release finish --showcommands --message "Release $VERSION" $VERSION
+GITTAG=master
+if [[ $(git rev-parse --abbrev-ref HEAD) != ${GITTAG} && $(git describe --exact-match --tags 2>/dev/null) != ${GITTAG} ]]; then
+    echo "Repository is currently not on branch/tag ${GITTAG}."
+    [[ "${ALLOW_DIRTY}" != "true" ]] && exit 1
+fi
 
-echo "After pushing changes to GitHub, please run"
-echo "  $ROOT/admin/update_docker.sh v$VERSION"
+THIS_REPO_VERSION=$(git -C $(dirname -- "$0") rev-parse HEAD)
+UPSTREAM_VERSION=$(git -C $(dirname -- "$0") ls-remote upstream master | cut -f1)
+if [[ $THIS_REPO_VERSION != $UPSTREAM_VERSION ]]; then
+    echo "Warning: git head of repo does not match upstream. You likely want to update this repo"
+    [[ "${ALLOW_DIRTY}" != "true" ]] && exit 1
+fi
+
+
+echo "Below is untested, echoing commands instead of running them"
+echo "Creating a draft release on github"
+echo gh -R Kattis/problemtools release create -d v$VERSION
+echo "After finalizing the release on GitHub, please:"
+echo " - trigger the pypi release workflow"
+echo " - run $ROOT/admin/update_docker.sh v$VERSION"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,374 @@
+kattis-problemtools (1.20250605) noble; urgency=medium
+
+  [ Tagl ]
+  * Set working directory for submission
+
+  [ Per Austrin ]
+  * small fixes to README.md
+
+  [ Tagl ]
+  * Support overwriting directories within submissions with included directories
+
+  [ JoelNiemela ]
+  * Simplify problem2html argparser and add type annotations
+  * Simplify problem2pdf argparser and add type annotations
+  * Add line break for readability
+  * Add type annotations to verifyproblem
+  * Use long name for langparam
+  * Fix potential error
+  * Use tuple destructuring syntax
+  * Don't remove argparser_basic_arguments
+  * Fix CodeFactor errors
+
+  [ Konráð Elí Sigurgeirsson ]
+  * Update README.md
+
+  [ Joel Niemelä ]
+  * Update README.md
+
+  [ JoelNiemela ]
+  * Update kotlin to version 1.8.10
+
+  [ Harry Zhang ]
+  * Fix not showing WA test case verifyproblem.py
+
+  [ Gunnar Kreitz ]
+  * Fix crash in verifyproblem when in or ans files are not utf-8
+
+  [ Pehr Söderman ]
+  * Restructure problem2html
+  * Restructure restrucure problem2pdf
+  * Improve debugging output
+  * Parse args properly.
+  * Reintroduce the get_subgroup, as it is needed for addproblem.
+  * Reintroduce get_attachment_paths, as it is needed for addproblem.
+
+  [ Tobias Meggendorfer ]
+  * Improved logging, fix unicode error, include_dir buildrun
+  * Guard better agains non-unicode feedback
+  * Revert delayed import
+  * Fix missed init, add test case
+
+  [ Maarten Sijm ]
+  * Explicitly set language versions for Java and Kotlin in languages.yaml
+
+  [ Tobias Meggendorfer ]
+  * Restore old format
+
+  [ Gunnar Kreitz ]
+  * Add github action to run pytest and flake8
+  * Remove travis config, point badges to github badge
+  * Check that all symlinks point to something existing within the problem package
+  * Forbid all absolute symlinks
+
+  [ Simon Lindholm ]
+  * Type annotation fixes
+  * Add -j flag for multi-threaded validation
+  * Compile submissions early, improve cleanup
+
+  [ Pehr Söderman ]
+  * Adding sanity checks for file sizes.
+  * Add UUID as an optional field in problem.yaml
+  * Include examples in the manifest
+  * Fixing running of tests
+  * Build debian packages in ci
+  * Cache and add packages
+  * Warn if sample is empty
+
+  [ Fredrik Niemelä ]
+  * Change team to user for default validator
+
+  [ Pehr Söderman ]
+  * Add a dependency on dvisvgm, which was missing
+
+  [ matistjati ]
+  * Add markdown support
+  * Added display math
+  * Add dependencies for markdown
+  * Style markdown tables
+  * Remove temp files
+  * Statement fix
+  * Some refactoring
+  * Added image support in markdown
+  * Added footnote support
+  * Code cleanup
+  * md -> html works
+
+  [ Gunnar Kreitz ]
+  * Remove non-standard judgeerror.txt from example problems
+
+  [ matistjati ]
+  * Make md styling more constistent with latex
+
+  [ Pehr Söderman ]
+  * Bump the language versions for c and c++
+  * Bump the language versions for Java
+
+  [ matistjati ]
+  * md->pdf and Reorganize code
+
+  [ Pehr Söderman ]
+  * GCC should use gnu17
+
+  [ matistjati ]
+  * Better md->pdf tables
+  * Interactive samples for pdf
+  * Remove bplusa
+  * PDF problem name
+  * Add dependencies
+  * Add problem names
+  * Added problem name to test hello package
+  * Improve security by running pandoc without shell capabilities
+  * Refactoring
+  * Even more refactoring
+  * Remove python3-markdown dependency
+  * Add problem id to pdf and small fixes
+
+  [ Pehr Söderman ]
+  * Update languages.yaml
+
+  [ Tagl ]
+  * Run interactive validation with submission's working directory
+
+  [ Matistjati ]
+  * Change Rust compilation flags
+
+  [ Hugo Söderbergh ]
+  * Remove deprecated functionality
+  * add build to .gitignore
+
+  [ JoelNiemela ]
+  * Add special case error message when user output file is empty
+  * Modify error message according to github comment
+
+  [ Hugo Söderbergh ]
+  * add command-line argument, begin generalizing Problem class
+  * small fix
+  * abstract problems further
+  * catch general exception for detecting problem-format
+  * Add some documentation
+  * New abstraction, ProblemPart which makes it easier to implement parts of problems
+  * Problem is no longer an abstract class
+  * ProblemStatement now exists for old and new format
+  * Add TODO for ProblemStatement
+  * Fix issues with ProblemStatement
+  * Add some documentation and some final fixes
+  * Small change
+  * Allow to give class-type for part in Problem.get
+  * Whoops small bug crashed code
+  * Fix bug that crashed multithreading for testcase-validation
+  * Mark ProblemPart.depends_on() as staticmethod
+
+  [ Matistjati ]
+  * Disable html
+  * Change to wikimedia example image
+  * Sanitize image sources
+  * Remove SVG dependency
+  * Better markdown styling
+  * Better sample styling
+  * Add \nextsample and \remainingsamples
+  * Better pdf error handling
+  * Use {{nextsample}} instead of \nextsample
+  * Relax image checking (implied by global regex on filenames)
+  * Add svg dependency
+
+  [ Gunnar Kreitz ]
+  * Explicitly install build-essential, as deb building blows up on it not being installed
+
+  [ Hugo Söderbergh ]
+  * fix issues with PR
+
+  [ Gunnar Kreitz ]
+  * Remove test of verifyproblem.generators (which has been removed)
+
+  [ Hugo Söderbergh ]
+  * Remove bad break-statement and increase consistency in dictionary access
+  * more concise regex
+  * Make Problem constructor default to legacy format
+  * make tests pass
+
+  [ Matistjati ]
+  * Add back warning/error logging
+
+  [ Gunnar Kreitz ]
+  * Add mypy to github workflow
+  * Change type from list to tuple, helping mypy and being clearer
+  * Fix name of exception (old one also worked, as parser does import * from Scanner, but felt weird)
+  * Add type annotations and abstract class markers
+  * Add getProblemPart for when we need to access problem.classes
+  * Add python tooling files (and vim swp files) to gitignore
+  * Fix signatures of run in VIVA and checktestdata to match superclass
+  * Fix/ignore type errors to let mypy catch errors everywhere but generatedata.py
+
+  [ ElliotRipa ]
+  * Make cls templates able work with either problem format
+  * Allow problem statement to use either problem format
+  * Make template.py detect format version instead
+  * Provisional updates
+  * Add formatversion.py
+  * Minor fixes in imports
+  * Move version specific functionality to separate file
+  * Change to flag '-v' for format-version
+  * Add missing parentheses
+  * Use dictionary instead of data objects for format data
+  * Make problem2html.py use -v to specify format version
+  * Add constants for version names
+  * Rollback problemset_0.1.cls
+  * Move initialisation of FORMAT_DATA to setup
+  * Make formatversion.py use dataobjects instead of dicts
+  * Fix documentation
+  * Remove unnecessary initialisation
+
+  [ Matistjati ]
+  * Start sanitization + apply feedback
+  * Better sanitization + lots of tests
+  * problem_statement -> statement
+  * Better md -> pdf sample rendering
+  * Another escape
+  * More careful with images
+  * Make samplexss more focused
+  * Experimentally reuse normal LaTeX rendering
+  * Use problemtools problem2pdf to handle md -> pdf
+  * Cleanup
+  * librsvg out of focus for this PR
+  * Ensure nh3
+  * Remove ghostscript sanitization. If it wasn't used before, it probably isn't needed
+  * Add nh3 to deb build
+  * Linting
+  * Add back ghostscript sanitization
+  * Remove unnecessary test
+
+  [ Gunnar Kreitz ]
+  * Add make clean to clean up support and the mess left by setuptools
+  * Change debian packaging to dh_virtualenv
+  * Update readme, adjusting installation instructions so we can use pip dependencies
+  * Convert from setup.py to pyproject.toml (and use setuptools-scm for versioning)
+  * Hook sdist to make python -m build work on a clean checkout
+  * Update wrapper scripts and README
+  * Update CI workflow to match readme for build requirements (plus build-essentials)
+  * Force dh_virtualenv to use builtin venv (debugging CI crash)
+  * Restructure CI/CD to separate deb building from python unit tests
+  * Stop exposing __version__, users should use importlib.metadata.version instead
+  * Hardcode path to python, as dh_virtualenv fails to discover it in CI
+  * Clean up version parsing. Accept 2023-07-draft and 2023-07 version strings
+  * Add pydantic models for parsing problem.yaml
+  * Limit problem.yaml config to only system defaults
+  * Use new metadata parsing mechanism, and start parsing config for 2023-07.
+  * Bump python version to 3.11
+  * Move tests to outside of the package
+  * Update manifest to include tests support files in sdist, and remove some clutter
+  * Remove old hack for plasTeX argument (we require >= 3.0 now)
+  * Clean up incompletely removed plastex_escape hack. Remove unused variable
+  * Clean up unused variables, old io import, and multiple commands on lines
+  * Clean up unused import and comparison with None
+  * Ruff format
+  * Clean up imports
+  * Fix minor things flagged by ruff
+  * Remove unused variables in tests
+  * Add ruff configuration
+  * Apply ruff formatting
+  * Add ruff pre-commit hook
+  * Replace flake8 with ruff (both linting and formatting)
+  * Fix incorrect formatting of pydantic errors
+  * Move is_interactive and is_scoring to be read from problem metadata directly
+  * Let Problem read and store problem format information. Warn about incomplete 2023-07 support
+  * Fix validator discovery for 2023-07. Run through all validation for 2023-07 (even if broken)
+
+  [ Matistjati ]
+  * Add nh3 as dependency
+  * Fix test import path
+  * Apply ruff formatting
+  * More robust footnote finding
+  * Don't double-escape HTML in samples
+  * Ghostscript fixes and tests
+
+  [ Gunnar Kreitz ]
+  * Fix loading a problem with empty problem.yaml and with no statements
+  * Add utility method to load problem metadata, including names from statements when needed
+  * Use load_metadata in verifyproblem. Add temporary fallback conf to fix crashes when failing to load metadata
+  * Use load_metadata in statement_util
+  * Add apt-get update in workflow to unbreak CI
+
+  [ Matistjati ]
+  * Convert some example problems to 2023-07-draft
+  * Add uuid to guess and oddecho
+  * Better formatting and error for output_validators
+
+  [ Pehr Söderman ]
+  * Add missing build requirements to debian build
+  * Update pyproject
+
+  [ Matistjati ]
+  * Remove now-duplicated import
+
+  [ Gunnar Kreitz ]
+  * Remove (AFAICT, broken) support for ancient tex statements (0.1)
+  * Fix bug where we complained about missing show_test_data_groups for non-legacy
+  * Default language to en. Remove unused --format-version
+  * Pass Template a filename to render, and pass that through to the latex template
+  * Rename problem.md to problem.en.md in tests to follow 2023-07-draft
+  * Refactor of rendering: unify statement finding code, and use Path more
+  * Use statement_util to find statements. Add more checks. Try rendering even when there are multiple statements in a language
+  * Make mypy more picky, also checking PlasTeX usage
+  * Simplify temporary file usage in markdown -> pdf flow
+  * Fix bug where problem2html cd:s to bad directory, crashing validation of multiple problems
+
+  [ Pehr Söderman ]
+  * Update link to kattis controlled domain.
+
+  [ Gunnar Kreitz ]
+  * Replace formatversion.FormatData with a StrEnum
+  * Add some documentation in the readme regarding current state of format versions
+  * Add colorlog to get colors for warnings and errors #312
+  * Add Swedish problem names
+  * Fix the logging plasTeX destroys
+  * Remove accidental commit
+  * Fix misleading error when missing problem statemetns
+  * Improve image handling in markdown statements
+  * Change URL to one that passes filename suffix filter
+  * Restructure error counters. Fix errors happening prior to check being ignored in count.
+  * Fix --bail_on_error and --werror being ignored before check
+  * Refactor problem loading so we can do fatal errors in setup
+  * Check file and directory names per standard
+  * Make missing/compilation failure in grader/output validator fatal
+  * Restore old API for accessing parts of a problem. Simplify part setup
+  * Change type of attachments.attachments from list[str] to list[Path]
+  * Convert Problem.metadata to a property to align better with other naming
+  * Expose computed timelim
+  * Add back problemtools.run.get_tool_path to API
+  * Large restructure of how our docker images are built.
+  * Remove old Dockerfile in root, unused afaict
+  * Add marker to let mypy use our type annotations
+  * Replace authors with Kattis AB (pypi only shows one). Set required python version
+  * Add script to build packages for pypi
+  * Fix incorrect error when verifying different. Add helpful hint when directory for wrong version exists
+  * Use problemtools/githubci image in workflow. Run verifyproblem on all examples.
+  * Check for incompatible types. Warn for unimplemented types
+  * Check format of interaction samples. #277 Don't warn about empty sample when it contains interactions.
+  * Add type methods for all types. Add convenience methods on Problem for easier access
+  * Improve warning for non-standard output validator languages #258
+  * Remove generatedata (never made it into the standard)
+  * Fix pytest dropping a guess.pdf in working directory. Check PDF magic bytes
+  * Add -d flag to update_docker to allow easier testing locally
+  * Fix broken git clone command (`${TAG}` expanded to empty string)
+  * Fix silly error in docker file, causing apt-get update not to run
+  * Add -d option to allow building in a dirty rep (to facilitate development of build scripts)
+  * Workflow that builds and pushes a package to testpypi
+  * Fix version computation when we build pypi packages
+  * Fix syntax error in github workflow file
+  * Fix bug where we crashed if we attempted to load/check twice
+  * Error if problem name exits in a language without a statement
+  * Add utility function uses_default_validator for output validation. Warn/error on multiple validators
+  * Fix new mypy error in mypy 1.16
+  * Fix missing support for imgbasedir in md2html
+  * Fix typo in Dockerfile.full causing it to lack a lot of languages
+  * Remove year from license - IANAL, but AFAICT it's not needed
+  * Add warning to pypi package script pointing to the github action now that that's set up
+  * Change update_docker to default to building from master (but keep :develop tag on docker)
+  * Add convenient way to run docker. Document need to install languages.
+
+ -- Gunnar Kreitz <gkreitz@kattis.com>  Thu, 05 Jun 2025 10:59:57 +0200
+
 kattis-problemtools (1.20231016) jammy; urgency=medium
 
   [ Don-Khue Le ]


### PR DESCRIPTION
Prepares for a new release (1.20250605)

- Updates release procedure (still partially untested, for obvious reasons).
- Updates the README, being a bit more clear about dependencies (#212) and how to run using docker

Next steps:

- Merge this PR to `develop`
- Create a PR merging `develop` into `master`
- Update repository settings, changing `master` to be the default branch, and move branch protection rules
- Create a release with github, adding the appropriate tag
- Build pypi and docker hub packages

Fixes #212