### PR TITLE
Fix sample missing from rendered problem statements

### DIFF
--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -48,7 +48,7 @@ class Template:
 
         sample_dir = problem_root / 'data' / 'sample'
         if sample_dir.is_dir():
-            self.samples = sorted({file.stem for file in sample_dir.iterdir() if file.suffix in ['in', 'interaction']})
+            self.samples = sorted({file.stem for file in sample_dir.iterdir() if file.suffix in ['.in', '.interaction']})
         else:
             self.samples = []
 

--- a/tests/test_latex.py
+++ b/tests/test_latex.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+import re
 import tempfile
 
-from problemtools import problem2pdf
+from problemtools import problem2html, problem2pdf
 
 
 def test_pdf_render_verifyproblem():
@@ -26,3 +27,35 @@ def test_pdf_render_problem2pdf():
             assert False, 'PDF conversion failed'
         with open(temp_filename, 'rb') as temp_file:
             assert temp_file.read(5) == b'%PDF-', 'Output header does not look like a PDF.'
+
+
+def test_html_render_different():
+    # Same options as typical problem2html usage
+    with tempfile.TemporaryDirectory() as temp_dir:
+        problem_path = Path(__file__).parent / '..' / 'examples' / 'different'
+        temp_dir = Path(temp_dir) / 'different_html'
+        options = problem2html.get_parser().parse_args(['-d', str(temp_dir), '-l', 'en', '-q', str(problem_path.resolve())])
+        problem2html.convert(options)
+        with open(temp_dir / 'index.html', 'r') as temp_file:
+            full_html = temp_file.read()
+            assert re.search('<html>', full_html)
+            assert re.search('A Different Problem', full_html)
+            assert re.search('Problem ID: different', full_html)
+            assert re.search('Write a program that computes', full_html)
+            assert re.search('71293781758123 72784', full_html)  # part of sample
+
+
+def test_html_render_guess():
+    # Same options as typical problem2html usage
+    with tempfile.TemporaryDirectory() as temp_dir:
+        problem_path = Path(__file__).parent / '..' / 'examples' / 'guess'
+        temp_dir = Path(temp_dir) / 'guess_html'
+        options = problem2html.get_parser().parse_args(['-d', str(temp_dir), '-l', 'en', '-q', str(problem_path.resolve())])
+        problem2html.convert(options)
+        with open(temp_dir / 'index.html', 'r') as temp_file:
+            full_html = temp_file.read()
+            assert re.search('<html>', full_html)
+            assert re.search('Guess the Number', full_html)
+            assert re.search('Problem ID: guess', full_html)
+            assert re.search('After each guess,', full_html)  # Short snippet from statement
+            assert re.search('995', full_html)  # part of sample


### PR DESCRIPTION
Fixes `problem2{html,pdf}` not including sample I/O when rendering latex problem statements.

Adds test coverage of problem2html for latex problem statements.