### PR TITLE
Fix multithreading crash

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -479,6 +479,9 @@ class TestCaseGroup(ProblemAspect):
         if not parent:
             self.set_symlinks()
 
+    def start_background_work(self, context: Context) -> None:
+        pass
+
     def __str__(self) -> str:
         return f'testcase group {self.name}'
 


### PR DESCRIPTION
Multithreading crashes with the latest problemtools version:
```
Loading problem <x>
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 2037, in <module>
    main()
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 2021, in main
    errors, warnings = prob.check()
                       ^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 1873, in check
    item.start_background_work(context)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'TestCaseGroup' object has no attribute 'start_background_work'
```

I have not dug into where along the way things went awry, but the fix is simple. We really need more automated tests.