### PR TITLE
Fuzz input validators for trailing whitespace

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -975,6 +975,7 @@ _JUNK_MODIFICATIONS = [
     _build_junk_modifier(
         'spaces added where there already is whitespace', r'\s', lambda m: m.group(0) + ' ' * random.randint(1, 5)
     ),
+    _build_junk_modifier('spaces added to the end of a line', r'\n', lambda m: m.group(0) + ' ' * random.randint(1, 5)),
     _build_junk_modifier('newlines added where there already are newlines', '\n', lambda m: '\n' * random.randint(2, 5)),
     _build_junk_modifier('leading zeros added to integers', r'(^|[^.]\b)([0-9]+)\b', r'\g<1>0000000000\g<2>'),
     _build_junk_modifier('trailing zeros added to real number decimal portion', r'\.[0-9]+\b', r'\g<0>0000000000'),


### PR DESCRIPTION
At the time of writing, 16 Aug 2025, both https://open.kattis.com/problems/procrastination and https://open.kattis.com/problems/ekkiminnforseti have trailing whitespaces in their samples. This is very minor, but should IMO not happen.

This PR adds tests that check the input validator will reject this.