### PR TITLE
Fuzz output validators

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1318,7 +1318,11 @@ class OutputValidators(ProblemPart):
 
             # For performance reasons, strongly limit the amount of testcases we run on
             fast_languages = {'c', 'cpp'}
-            num_testcases = 3 if all(v.language.lang_id in fast_languages for v in self._validators) else 1
+            all_validators_are_fast = True
+            for val in self._validators:
+                if isinstance(val, run.SourceCode):
+                    all_validators_are_fast &= val.language.lang_id in fast_languages
+            num_testcases = 3 if all_validators_are_fast else 1
             test_cases = self.problem.testdata.get_all_testcases()[:num_testcases]
             # Malformed cases that a poorly-written output validator might crash on
             # Note that these might be valid output, so we only check if it crashes


### PR DESCRIPTION
I suspect that many output validators out there are not crash-proof against all contestant output. I think that adding a couple of evil testcases might catch some poorly written ones.

I decided to only run it on samples, since performance actually becomes a concern if you have lots of testcases (especially if they don't deduplicate symlinks. Not sure if we do this, will have to check in the future).

For the contents of the cases, I just tried to think of ways I to incorrectly write some existing validators. Perhaps @niemela or @gkreitz could look into judge errors on Kattis and add a minimal version of what killed the output validator?