### PR TITLE
Multipass support

### DIFF
--- a/problemtools/metadata.py
+++ b/problemtools/metadata.py
@@ -219,6 +219,13 @@ class Metadata(BaseModel):
     def is_scoring(self) -> bool:
         return ProblemType.SCORING in self.type
 
+    def is_custom_score_allowed(self) -> bool:
+        match self.problem_format_version:
+            case FormatVersion.LEGACY:
+                return self.legacy_custom_score
+            case FormatVersion.V_2023_07:
+                return self.is_scoring()
+
     def is_interactive(self) -> bool:
         return ProblemType.INTERACTIVE in self.type
 

--- a/problemtools/metadata.py
+++ b/problemtools/metadata.py
@@ -226,6 +226,13 @@ class Metadata(BaseModel):
             case FormatVersion.V_2023_07:
                 return self.is_scoring()
 
+    def is_custom_score_mandatory(self) -> bool:
+        match self.problem_format_version:
+            case FormatVersion.LEGACY:
+                return self.legacy_custom_score
+            case FormatVersion.V_2023_07:
+                return False
+
     def is_interactive(self) -> bool:
         return ProblemType.INTERACTIVE in self.type
 

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -414,7 +414,7 @@ class TestCase(ProblemAspect):
 
             def run_submission(infile: Path) -> SubmissionResult:
                 return self._problem.output_validators.validate_interactive(
-                    self, sub, timelim_high, self._problem.submissions, infile, str(feedback_dir)
+                    self, sub, timelim_high, self._problem.submissions, str(infile), str(feedback_dir)
                 )
         else:
 

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -676,7 +676,10 @@ class TestCaseGroup(ProblemAspect):
             if os.path.basename(self._datadir) != 'sample':
                 self.error(f'Testcase group {self._datadir} exists, but does not contain any testcases')
             else:
-                if not (self._problem.is_interactive() and glob.glob(os.path.join(self._datadir, '*.interaction'))):
+                if not (
+                    (self._problem.is_interactive() or self._problem.is_multi_pass())
+                    and glob.glob(os.path.join(self._datadir, '*.interaction'))
+                ):
                     self.warning(f'Sample testcase group {self._datadir} exists, but does not contain any testcases')
 
         # Check whether a <= b according to a natural sorting where numeric components

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1481,8 +1481,14 @@ class OutputValidators(ProblemPart):
         submission_args = submission.get_runcmd(memlim=self.problem.metadata.limits.memory)
 
         val_memlim = self.problem.metadata.limits.validation_memory
-        for val in self._actual_validators():
+        for i, val in enumerate(self._actual_validators()):
             if val.compile()[0]:
+                # If we are running multiple output validators in legacy, make sure to wipe it
+                # If we are running multipass, i will always be 0 and we do not accidentally wipe feedback
+                if i > 0 and feedback_dir_path:
+                    shutil.rmtree(feedback_dir_path)
+                    Path(feedback_dir_path).mkdir()
+
                 if feedback_dir_path:
                     feedbackdir = feedback_dir_path
                 else:
@@ -1555,8 +1561,14 @@ class OutputValidators(ProblemPart):
         flags = (
             self.problem.metadata.legacy_validator_flags.split() + testcase.testcasegroup.config['output_validator_flags'].split()
         )
-        for val in self._actual_validators():
+        for i, val in enumerate(self._actual_validators()):
             if val.compile()[0]:
+                # If we are running multiple output validators in legacy, make sure to wipe it
+                # If we are running multipass, i will always be 0 and we do not accidentally wipe feedback
+                if i > 0 and feedback_dir_path:
+                    shutil.rmtree(feedback_dir_path)
+                    Path(feedback_dir_path).mkdir()
+
                 if feedback_dir_path:
                     feedbackdir = feedback_dir_path
                 else:


### PR DESCRIPTION
I dislike the inline functions on line 415 and 421, but ruff demands it...

I do not try to prevent the submission from passing information out of bound. In my opinion, doing so would just be cosmetic, as it's impossible to do it fully without building a sandbox.

In a follow-up PR, I will fix multipass sample rendering when the source is tex. I have fixed it for md -> html in this PR.