### PR TITLE
Multipass sample rendering

### DIFF
--- a/problemtools/statement_util.py
+++ b/problemtools/statement_util.py
@@ -282,17 +282,33 @@ def format_interactive_sample(sample_root: str, sample: str, casenum: int, is_in
     def format_pass_content(content: list[str]) -> str:
         block = []
         if is_interactive:
-            for interaction in content:
-                line_type = ''
-                if interaction[0] == '>':
-                    line_type = 'sampleinteractionwrite'
-                elif interaction[0] == '<':
-                    line_type = 'sampleinteractionread'
-                else:
-                    log.warning(f'Interaction had unknown prefix {interaction[0]}')
-                data = html.escape(interaction[1:])
+            message_type = '$'
+            message: list[str] = []
 
-                block.append(f'<div class="{line_type}"><pre>{data}</pre></div>')
+            def format_message(message_type: str, message: list[str]) -> str:
+                if message_type == '>':
+                    line_type = 'sampleinteractionwrite'
+                elif message_type == '<':
+                    line_type = 'sampleinteractionread'
+                return f'<div class="{line_type}"><pre>{"".join(message)}</pre></div>'
+
+            for interaction in content:
+                if len(interaction) == 0:
+                    continue
+                if interaction[0] not in ('<', '>'):
+                    log.warning(f'Interaction had unknown prefix {interaction[0]}')
+                    continue
+
+                if interaction[0] != message_type and message_type != '$':
+                    block.append(format_message(message_type, message))
+                    message = []
+
+                message_type = interaction[0]
+                data = html.escape(interaction[1:])
+                message.append(data)
+
+            if message:
+                block.append(format_message(message_type, message))
         else:
             input_lines = [html.escape(line[1:]) for line in content if line.startswith('<')]
             output_lines = [html.escape(line[1:]) for line in content if line.startswith('>')]
@@ -315,8 +331,8 @@ def format_interactive_sample(sample_root: str, sample: str, casenum: int, is_in
         if interaction.startswith('---'):
             passes.append(curr_pass)
             curr_pass = []
-            continue
-        curr_pass.append(interaction)
+        else:
+            curr_pass.append(interaction)
 
     if len(curr_pass):
         passes.append(curr_pass)

--- a/problemtools/templates/html/Themes/default/problem.css
+++ b/problemtools/templates/html/Themes/default/problem.css
@@ -69,6 +69,7 @@ table.sample pre {
 
 table.sample td {
     border: 1px solid black;
+    width: 50%;
 }
 
 div.sampleinteractionread {

--- a/problemtools/templates/html/Themes/default/problem.css
+++ b/problemtools/templates/html/Themes/default/problem.css
@@ -63,6 +63,10 @@ table.sample th {
     width: 50%;    
 }
 
+table.sample pre {
+    margin: 0;
+}
+
 table.sample td {
     border: 1px solid black;
 }

--- a/problemtools/templates/html/problemsetmacros.zpts
+++ b/problemtools/templates/html/problemsetmacros.zpts
@@ -24,16 +24,46 @@ name: sampletable
 name: sampletableinteractive
 <table class="sample" summary="sample data">
    <tr>
-      <th style="text-align:left; width:33%;" tal:content="self/attributes/read"></th>
+      <th style="text-align:left; width:33%;" tal:content="self/attributes/read" tal:condition="python: not self.attributes.get('is_multi_pass')"></th>
       <th style="text-align:center; width:33%;" tal:content="self/attributes/header"></th>
-      <th style="text-align:right; width:33%;" tal:content="self/attributes/write"></th>
+      <th style="text-align:right; width:33%;" tal:content="self/attributes/write" tal:condition="python: not self.attributes.get('is_multi_pass')"></th>
    </tr>
 </table>
+
+
 <tal:block tal:repeat="message self/attributes/messages">
-   <div tal:attributes="class string:sampleinteraction${message/mode}">
+   <tal:block tal:condition="python: message['mode'] == 'newpass' and self.attributes.get('is_multi_pass')">
+      <table class="sample" summary="sample data">
+         <tr>
+            <th style="text-align:left; width:33%;" tal:content="self/attributes/read"></th>
+            <th style="text-align:center; width:33%;" tal:content="python: 'Pass %s' % message['data']"></th>
+            <th style="text-align:right; width:33%;" tal:content="self/attributes/write"></th>
+         </tr>
+      </table>
+   </tal:block>
+
+   <div tal:condition="python: message['mode'] in ('read', 'write') and self.attributes.get('is_interactive', False)"
+      tal:attributes="class string:sampleinteraction${message/mode}">
       <pre tal:content="message/data"></pre>
    </div>
+
+   <div tal:condition="python: message['mode'] == 'batch_sample' and not self.attributes.get('is_interactive', False)"
+      tal:attributes="class string:sampleinteraction${message/mode}">
+      
+      <table class="sample" summary="sample data">
+         <tr>
+            <td>
+               <pre tal:content="message/in_data"></pre>
+            </td>
+            <td>
+               <pre tal:content="message/out_data"></pre>
+            </td>
+         </tr>
+      </table>
+   </div>
 </tal:block>
+
+
 
 name: illustration
 <div class="illustration" tal:attributes="style string:width:${self/style/width}">

--- a/problemtools/templates/markdown_html/problem.css
+++ b/problemtools/templates/markdown_html/problem.css
@@ -55,6 +55,7 @@ table:not(.sample) td {
 .sample td {
     vertical-align: top;
     border: 1px solid black;
+    width: 50%;
 }
 
 .sample pre {

--- a/problemtools/tex2html.py
+++ b/problemtools/tex2html.py
@@ -4,7 +4,6 @@ import string
 import argparse
 from pathlib import Path
 
-from . import metadata
 from . import template
 
 
@@ -32,10 +31,6 @@ def convert(problem_root: Path, options: argparse.Namespace, statement_file: Pat
         tex = plasTeX.TeX.TeX(file=texfile)
 
         ProblemsetMacros.init(tex)
-
-        problem_metadata, _ = metadata.load_metadata(problem_root)
-        tex.ownerDocument.userdata['is_multi_pass'] = problem_metadata.is_multi_pass()
-        tex.ownerDocument.userdata['is_interactive'] = problem_metadata.is_interactive()
 
         tex.ownerDocument.config['general']['copy-theme-extras'] = options.css
         if not options.headers:

--- a/problemtools/tex2html.py
+++ b/problemtools/tex2html.py
@@ -4,6 +4,7 @@ import string
 import argparse
 from pathlib import Path
 
+from . import metadata
 from . import template
 
 
@@ -31,6 +32,10 @@ def convert(problem_root: Path, options: argparse.Namespace, statement_file: Pat
         tex = plasTeX.TeX.TeX(file=texfile)
 
         ProblemsetMacros.init(tex)
+
+        problem_metadata, _ = metadata.load_metadata(problem_root)
+        tex.ownerDocument.userdata['is_multi_pass'] = problem_metadata.is_multi_pass()
+        tex.ownerDocument.userdata['is_interactive'] = problem_metadata.is_interactive()
 
         tex.ownerDocument.config['general']['copy-theme-extras'] = options.css
         if not options.headers:

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1444,13 +1444,7 @@ class OutputValidators(ProblemPart):
                 except Exception as e:
                     return SubmissionResult('JE', reason=f'failed to parse validator score: {e}')
             else:
-                # If we're running multipass, we do not need to output a score after every pass
-                # We accept the small risk of allowing a non-multipass output validator to not output score.txt
-                # if it produces a file called nextpass.in
-                if (Path(feedbackdir) / 'nextpass.in').exists():
-                    score = 0
-                else:
-                    return SubmissionResult('JE', reason='problem has custom scoring but validator did not produce "score.txt"')
+                return SubmissionResult('JE', reason='problem has custom scoring but validator did not produce "score.txt"')
 
         return SubmissionResult('AC', score=score)
 


### PR DESCRIPTION
Add support rendering multipass samples. Progress:
- [X] latex -> html
- [X] md -> html
- [ ] latex/md -> pdf (these use the same cls file)
- [ ] test on a local kattis instance

Also a little random clean-up

Multipass batch
<img width="1906" height="464" alt="image" src="https://github.com/user-attachments/assets/c306d034-b613-4703-bfb4-b7dd769adc97" />

Multipass interactive
<img width="1917" height="315" alt="image" src="https://github.com/user-attachments/assets/073eac73-29ad-4313-bcc2-b700d709eafd" />
