### PR TITLE
Add --version flag to command line tools

### DIFF
--- a/problemtools/problem2html.py
+++ b/problemtools/problem2html.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from . import tex2html
 from . import md2html
 from . import statement_util
+from .version import add_version_arg
 
 
 def convert(options: argparse.Namespace, force_statement_file: Path | None = None) -> None:
@@ -99,6 +100,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-q', '--quiet', dest='quiet', action='store_true', help='quiet', default=False)
     parser.add_argument('-i', '--imgbasedir', dest='imgbasedir', default='')
     parser.add_argument('problem', help='the problem to convert')
+    add_version_arg(parser)
 
     return parser
 

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from . import template
 from . import statement_util
+from .version import add_version_arg
 
 
 def convert(options: argparse.Namespace, force_statement_file: Path | None = None) -> bool:
@@ -158,6 +159,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument('-l', '--language', dest='language', help='choose language (2-letter code)', default='en')
     parser.add_argument('-n', '--no-pdf', dest='nopdf', action='store_true', help='run pdflatex in -draftmode', default=False)
     parser.add_argument('problem', help='the problem to convert')
+    add_version_arg(parser)
 
     return parser
 

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -35,6 +35,7 @@ from . import problem2pdf
 from . import run
 from . import statement_util
 from .formatversion import FormatVersion, get_format_version
+from .version import add_version_arg
 
 from abc import ABC
 from typing import Any, Callable, ClassVar, Literal, Pattern, Match, ParamSpec, TypeVar
@@ -2155,6 +2156,7 @@ def argparser() -> argparse.ArgumentParser:
         help='run validation using multiple threads. This will make timings less reliable, but can be convenient during development',
     )
 
+    add_version_arg(parser)
     argparser_basic_arguments(parser)
 
     parser.add_argument('problemdir', nargs='+')

--- a/problemtools/version.py
+++ b/problemtools/version.py
@@ -1,0 +1,22 @@
+import argparse
+
+from .formatversion import FormatVersion
+
+
+def add_version_arg(parser: argparse.ArgumentParser) -> None:
+    """Adds the --version argument to the parser"""
+    # setuptools-scm drops a _version file in our package, so read version from there.
+    # Fall back to "unknown", e.g., on a dev machine or in CI pipelines where setuptools
+    # has not been run
+    try:
+        from . import _version  # type: ignore
+
+        version = _version.version
+    except (ImportError, ModuleNotFoundError, AttributeError):
+        version = 'unknown'
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'%(prog)s {version}. Supports problem format {FormatVersion.LEGACY}, and partial (experimental) support for {FormatVersion.V_2023_07}',
+    )


### PR DESCRIPTION
Adds a --version flag to our command line tools, getting the version of problemtools and what format versions we support.