### PR TITLE
Load language config from parent of problem dir, if present #178

### DIFF
--- a/problemtools/languages.py
+++ b/problemtools/languages.py
@@ -6,6 +6,7 @@ of programming languages.
 import fnmatch
 import re
 import string
+from pathlib import Path
 
 from . import config
 
@@ -218,10 +219,10 @@ class Languages(object):
             priorities[lang.priority] = lang_id
 
 
-def load_language_config():
+def load_language_config(probdir_parent: Path) -> Languages:
     """Load language configuration.
 
     Returns:
         Languages object for the set of languages.
     """
-    return Languages(config.load_config('languages.yaml'))
+    return Languages(config.load_config('languages.yaml', [probdir_parent]))

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1902,7 +1902,7 @@ class Problem(ProblemAspect):
         self.probdir = os.path.realpath(probdir)
         self.shortname: str = os.path.basename(self.probdir)
         super().__init__(self.shortname, self)
-        self.language_config = languages.load_language_config()
+        self.language_config = languages.load_language_config(Path(self.probdir).parent)
         self.testcase_by_infile: dict[str, TestCase] = {}
         self.loaded = False
         self._metadata: metadata.Metadata | None = None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,9 +5,9 @@ from problemtools import config
 
 
 def config_paths_mock():
-    import os
+    from pathlib import Path
 
-    return [os.path.join(os.path.dirname(__file__), 'config1'), os.path.join(os.path.dirname(__file__), 'config2')]
+    return [Path(__file__).parent / 'config1', Path(__file__).parent / 'config2']
 
 
 def test_load_basic_config(monkeypatch):


### PR DESCRIPTION
Parse `languages.yaml` from the parent directory of the problem, if it exists, allowing it to override settings. The intent of this feature is to allow contest-specific language configuration to be put into the root of a git repo containing the problemset.

Also adds type annotations and rewrites `config.py` to use `Path`.

Fixes #178