### PR TITLE
Check if there are incorrect submission directories

### DIFF
--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -37,6 +37,8 @@ class FormatVersion(StrEnum):
             case FormatVersion.LEGACY:
                 return ['accepted', 'partially_accepted', 'wrong_answer', 'time_limit_exceeded', 'run_time_error']
             case FormatVersion.V_2023_07:
+                # TODO: parse submissions.yaml if applicable, since
+                # 2023-07 and later formats support adding more submission directories
                 return ['accepted', 'rejected', 'wrong_answer', 'time_limit_exceeded', 'run_time_error', 'brute_force']
 
     # Support 2023-07 and 2023-07-draft strings.
@@ -46,9 +48,6 @@ class FormatVersion(StrEnum):
         if value == '2023-07':
             return cls.V_2023_07
         return None
-
-
-ALL_FORMAT_VERSIONS = [FormatVersion.LEGACY, FormatVersion.V_2023_07]
 
 
 def get_format_version(problem_root: Path) -> FormatVersion:

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -31,6 +31,14 @@ class FormatVersion(StrEnum):
             case FormatVersion.V_2023_07:
                 return 'output_validator'
 
+    @property
+    def submission_directories(self) -> list[str]:
+        match self:
+            case FormatVersion.LEGACY:
+                return ['accepted', 'partially_accepted', 'wrong_answer', 'time_limit_exceeded', 'run_time_error']
+            case FormatVersion.V_2023_07:
+                return ['accepted', 'rejected', 'wrong_answer', 'time_limit_exceeded', 'run_time_error', 'brute_force']
+
     # Support 2023-07 and 2023-07-draft strings.
     # This method should be replaced with an alias once we require python 3.13
     @classmethod
@@ -38,6 +46,9 @@ class FormatVersion(StrEnum):
         if value == '2023-07':
             return cls.V_2023_07
         return None
+
+
+ALL_FORMAT_VERSIONS = [FormatVersion.LEGACY, FormatVersion.V_2023_07]
 
 
 def get_format_version(problem_root: Path) -> FormatVersion:

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -23,6 +23,7 @@ import copy
 import random
 import traceback
 import uuid
+import difflib
 from pathlib import Path
 
 import colorlog
@@ -35,7 +36,7 @@ from . import problem2html
 from . import problem2pdf
 from . import run
 from . import statement_util
-from .formatversion import FormatVersion, get_format_version
+from .formatversion import FormatVersion, get_format_version, ALL_FORMAT_VERSIONS
 from .version import add_version_arg
 
 from abc import ABC
@@ -2044,6 +2045,7 @@ class Problem(ProblemAspect):
 
             self._check_symlinks()
             self._check_file_and_directory_names()
+            self._check_submission_directory_names()
 
             run.limit.check_limit_capabilities(self)
 
@@ -2066,6 +2068,37 @@ class Problem(ProblemAspect):
             # the directory tree it uses.
             context.wait_for_background_work()
         return self.errors, self.warnings
+
+    def _check_submission_directory_names(self):
+        """Heuristically check if submissions contain any directories that will be ignored because of typos or format mismatches"""
+        submission_directories = [p.name for p in (Path(self.probdir) / 'submissions').glob('*') if p.is_dir()]
+        if len(submission_directories) == 0:
+            return
+
+        def most_similar(present_dir: str, format_version: FormatVersion):
+            similarities = [
+                (spec_dir, difflib.SequenceMatcher(None, present_dir, spec_dir).ratio())
+                for spec_dir in format_version.submission_directories
+            ]
+            return max(similarities, key=lambda x: x[1])
+
+        for present_dir in submission_directories:
+            most_similar_dir, max_similarity = most_similar(present_dir, self.format)
+
+            if max_similarity == 1:
+                # Exact match, no typo
+                continue
+
+            if 0.75 <= max_similarity:
+                self.warning(f'Potential typo: directory submissions/{present_dir} is similar to {most_similar_dir}')
+            else:
+                for other_version in [v for v in ALL_FORMAT_VERSIONS if v != self.format]:
+                    _, max_similarity = most_similar(present_dir, other_version)
+                    if max_similarity == 1:
+                        self.warning(
+                            f'Directory submissions/{present_dir} is not part of format version {self.format}, but part of {other_version}'
+                        )
+                        break
 
     def _check_symlinks(self):
         """Check that all symlinks point to something existing within the problem package"""

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -36,7 +36,7 @@ from . import problem2html
 from . import problem2pdf
 from . import run
 from . import statement_util
-from .formatversion import FormatVersion, get_format_version, ALL_FORMAT_VERSIONS
+from .formatversion import FormatVersion, get_format_version
 from .version import add_version_arg
 
 from abc import ABC
@@ -2092,7 +2092,7 @@ class Problem(ProblemAspect):
             if 0.75 <= max_similarity:
                 self.warning(f'Potential typo: directory submissions/{present_dir} is similar to {most_similar_dir}')
             else:
-                for other_version in [v for v in ALL_FORMAT_VERSIONS if v != self.format]:
+                for other_version in [v for v in FormatVersion if v != self.format]:
                     _, max_similarity = most_similar(present_dir, other_version)
                     if max_similarity == 1:
                         self.warning(


### PR DESCRIPTION
For each directory in submissions:
- If it exactly matches some directory from the current problem version, do nothing
- Otherwise, if it almost matches, warn for a potential typo
- Otherwise, check if it matches some other directory from another format version

Sample output:
```
WARNING Potential typo: directory submissions/partially_acceptedd is similar to partially_accepted
WARNING Directory submissions/brute_force is not part of format version legacy, but part of 2023-07-draft
```

The magic value 0.75 was chosen quite arbitrarily.
```
>>> SequenceMatcher(None, 'wrong-answer', 'wrong_answer').ratio()
0.9166666666666666
>>> SequenceMatcher(None, 'wrong-answER', 'wrong_answer').ratio()
0.75
>>> SequenceMatcher(None, 'partially_ac', 'partially_accepted').ratio()
0.8
>>> SequenceMatcher(None, 'acc', 'accepted').ratio()
0.5454545454545454
>>> SequenceMatcher(None, 'Accecpted', 'accepted').ratio()
0.8235294117647058
```