### PR TITLE
Fix missing header in default validator

### DIFF
--- a/support/default_validator/default_validator.cc
+++ b/support/default_validator/default_validator.cc
@@ -7,6 +7,7 @@
 #include <cassert>
 #include <cmath>
 #include <cstdarg>
+#include <tuple>
 
 const int EXIT_AC = 42;
 const int EXIT_WA = 43;


### PR DESCRIPTION
I needed \<tuple\> for std::tie to compile (on g++ 9.4.0).