### PR TITLE
Fix multithreaded symlink crash

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1730,10 +1730,12 @@ class Runner:
         if not item.matches_filter(self._context.data_filter):
             return []
         if isinstance(item, TestCase):
-            if item.reuse_result_from:
-                return self._gather_testcases(item.reuse_result_from)
-            else:
-                return [item]
+            # If testcase is symlink, recursively follow the symlinks until we get a real testcase, ignoring
+            # whether the name of testcases pointed to matches the filter
+            while item.reuse_result_from:
+                item = item.reuse_result_from
+
+            return [item]
         elif item not in self._done_groups:
             ret = []
             for child in item.get_testcases() + item.get_subgroups():


### PR DESCRIPTION
Suppose we have a problem with two groups: `g1` and `g2`. Suppose that `g2` has a testcase that is a symlink pointing to a testcase in `g1`. Then, running

`verifyproblem <problem> -j 3 -d secret/g2/`

Causes a crash.

The issue is that the code for gathering testcases for multithreaded eval is incorrect.

```python
    def _gather_testcases(self, item: TestCase | TestCaseGroup) -> list[TestCase]:
        if not item.matches_filter(self._context.data_filter):
            return []
        if isinstance(item, TestCase):
            if item.reuse_result_from:
                return self._gather_testcases(item.reuse_result_from)
            else:
                return [item]
        elif item not in self._done_groups:
            ret = []
            for child in item.get_testcases() + item.get_subgroups():
                ret.extend(self._gather_testcases(child))
            return ret
        else:
            return []
```

In the case given above, it will recurse to the new file and check the filter, rejecting it. But this is "obviously" incorrect. My fix is to forcefully follow the symlinks until we get to a real case.

The crash:
<details>

```bash
verifyproblem . -s joshuan2.py -t 1 -j 3 -d secret/g2/
Loading problem publiksport
Checking config
Checking statement
Checking validators
Checking graders
Checking data
Checking submissions
   Slowest AC runtime: -, setting timelim to 1 secs, safety margin to 2 secs
Running joshuan2.py (Python 3 w/Pypy) on testcase secret/g1/001-g1-n2-moderandom...Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 2291, in <module>
    main()
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 2275, in main
    errors, warnings = prob.check()
                       ^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 2096, in check
    item.check(context)
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 1917, in check
    res = self.check_submission(sub, context, acr, timelim, timelim_high)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 1811, in check_submission
    result, result_low, result_high = self.problem.testdata.run_submission(sub, runner, context)
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 742, in run_submission
    res, res_low, res_high = child.run_submission(sub, runner, context)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 742, in run_submission
    res, res_low, res_high = child.run_submission(sub, runner, context)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 742, in run_submission
    res, res_low, res_high = child.run_submission(sub, runner, context)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 337, in run_submission
    (res, res_low, res_high), reused = runner.run(self)
                                       ^^^^^^^^^^^^^^^^
  File "/home/matistjati/software/problemtools/problemtools/verifyproblem.py", line 1702, in run
    result = self._queues[testcase].get()
             ~~~~~~~~~~~~^^^^^^^^^^
KeyError: <__main__.TestCase object at 0x7ff4297591c0>
```

</details>