### PR TITLE
Set cwd when running input validators

### DIFF
--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1158,7 +1158,7 @@ class InputValidators(ProblemPart):
                 for flags_str in all_flags:
                     flags = flags_str.split()
                     for val in self._validators:
-                        status, _ = val.run(file_name, args=flags)
+                        status, _ = val.run(file_name, args=flags, work_dir=self.problem.tmpdir)
                         if os.WEXITSTATUS(status) != 42:
                             break
                     else:
@@ -1180,7 +1180,7 @@ class InputValidators(ProblemPart):
                     for flags_str in all_flags:
                         flags = flags_str.split()
                         for val in self._validators:
-                            status, _ = val.run(file_name, args=flags)
+                            status, _ = val.run(file_name, args=flags, work_dir=self.problem.tmpdir)
                             if os.WEXITSTATUS(status) != 42:
                                 # expected behavior; validator rejects modified input
                                 return False
@@ -1208,7 +1208,7 @@ class InputValidators(ProblemPart):
 
         for val in self._validators:
             with tempfile.NamedTemporaryFile() as outfile, tempfile.NamedTemporaryFile() as errfile:
-                status, _ = val.run(testcase.infile, outfile.name, errfile.name, args=flags)
+                status, _ = val.run(testcase.infile, outfile.name, errfile.name, args=flags, work_dir=self.problem.tmpdir)
                 if not os.WIFEXITED(status):
                     emsg = f'Input format validator {val} crashed on input {testcase.infile}'
                 elif os.WEXITSTATUS(status) != 42:


### PR DESCRIPTION
Closes #336. I think that this is the right solution- changing the limit ourselves adds more noise to the codebase as opposed to just masking it by dumping the core in the temporary working directory.

Doesn't result in a statistically significant slowdown.
```python
matistjati@DESKTOP-BJV27M6:~/po/swedish-olympiad-2026/lager2$ ulimit -c unlimited
matistjati@DESKTOP-BJV27M6:~/po/swedish-olympiad-2026/lager2$ time ~/kattis/problemtools/bin/verifyproblem.sh fredrikspizzeria -p data
Loading problem fredrikspizzeria
Checking data
fredrikspizzeria tested: 0 errors, 0 warnings

real    0m25.040s
user    0m20.809s
sys     0m2.376s
matistjati@DESKTOP-BJV27M6:~/po/swedish-olympiad-2026/lager2$ ulimit -c 0
matistjati@DESKTOP-BJV27M6:~/po/swedish-olympiad-2026/lager2$ time ~/kattis/problemtools/bin/verifyproblem.sh fredrikspizzeria -p data
Loading problem fredrikspizzeria
Checking data
fredrikspizzeria tested: 0 errors, 0 warnings

real    0m24.472s
user    0m20.102s
sys     0m2.428s
```