### PR TITLE
Update github actions to latest versions

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -18,7 +18,7 @@ jobs:
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0  # We need full history for setuptools_scm to figure out version
     - name: Set safe directory (work around checkout not doing that properly for containers)
@@ -34,7 +34,7 @@ jobs:
         rm -f dist/*.whl
         cp wheelhouse/*.whl dist
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: python-package-distributions
         path: dist/
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/
@@ -80,7 +80,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,6 +50,8 @@ jobs:
     - uses: actions/checkout@v6
       with:
         submodules: true
+    - name: Set safe directory (work around checkout not doing that properly for containers)
+      run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
     - name: Build debian packages
       run:  |
         make builddeb

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -21,9 +21,9 @@ jobs:
     container:
       image: problemtools/githubci:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
     container:
       image: problemtools/githubci:latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Build debian packages


### PR DESCRIPTION
Our CI looks like it's currently breaking. During builds, we get warnings about too old github actions, so let's start by bumping them all to the latest version.

Adds a workaround for the checkout action failing to set safe.directory when used with a container, as that turned out to be what was breaking the build (setuptools-scm tried to read the git version).

I wish there was better documentation on github actions versions, and a better way to test these... The pypi changes in this PR are untested, but I can't see a way to test those except for merging this and doing a test-pypi release.