### PR TITLE
Fix interactive output validator flags

### DIFF
--- a/problemtools/judge/execute.py
+++ b/problemtools/judge/execute.py
@@ -124,6 +124,7 @@ def _run_interactive(
             ['1', str(math.ceil(2 * timelim))]
             + output_validator.get_runcmd(memlim=metadata.limits.validation_memory)
             + [str(infile), str(testcase.ansfile_path), str(feedback_dir) + os.sep]
+            + testcase.output_validator_flags
             + [';']
             + sub.get_runcmd(memlim=metadata.limits.memory)
         ),


### PR DESCRIPTION
Fixes #418. Tested on a local problem. Tests fail due to unrelated code (mypy caugt some type mixing, first merge #422 and then I will rebase).