### PR TITLE
Support colored text in HTML rendering pipeline for LaTeX

### DIFF
--- a/problemtools/templates/latex/problemset.cls
+++ b/problemtools/templates/latex/problemset.cls
@@ -48,6 +48,7 @@
 \RequirePackage{url}              % Urls
 \RequirePackage[normalem]{ulem}   % \sout
 \RequirePackage[colorlinks=true,implicit=false]{hyperref}
+\RequirePackage{color}            % Colored text
 \RequirePackage{longtable}        % Used by Pandoc
 \RequirePackage{booktabs}         % Used by Pandoc
 \ifplastex\else


### PR DESCRIPTION
Colors in pdf currently work (and have done so far a long time):

<img width="1036" height="393" alt="image" src="https://github.com/user-attachments/assets/7c40860f-7782-4dac-b50a-fff1c48aa03c" />

While support is lacking in HTML. I'm surprised the fix was this easy. In case we for some reason don't want colors in HTML, I think we should remove them from PDF; many people primarily use PDFs as statement previews, and have gotten tricked into shipping problem statements with colors. We ought to create a better default CSS file, but that's for another issue.

I have not tested this in a real Kattis instance.
