### PR TITLE
Fix not parsing `score.txt` in 2025-09 packages

### DIFF
--- a/problemtools/judge/validate.py
+++ b/problemtools/judge/validate.py
@@ -60,7 +60,7 @@ def _parse_validator_result(
         return SubmissionResult('JE', reason='validator produced "score.txt" but problem does not have custom scoring activated')
 
     score: float | None = None
-    if metadata.is_custom_score_mandatory():
+    if metadata.is_custom_score_allowed():
         if score_file.is_file():
             try:
                 score = float(score_file.read_text())
@@ -68,7 +68,7 @@ def _parse_validator_result(
                 return SubmissionResult('JE', reason=f'failed to parse validator score: {e}')
         elif metadata.is_multi_pass() and (feedback_dir / 'nextpass.in').is_file():
             score = 0.0
-        else:
+        elif metadata.is_custom_score_mandatory():
             return SubmissionResult('JE', reason='problem has custom scoring but validator did not produce "score.txt"')
 
     return SubmissionResult('AC', score=score)


### PR DESCRIPTION
We had a logic bug where we failed to parse score.txt at all in the new problem format.

Note that we still do not support `score_multiplier.txt`, and that this check should be made tighter (preferably after fixing https://github.com/Kattis/problem-package-format/issues/581 )