### PR TITLE
Fix submission size computation

### DIFF
--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -58,6 +58,7 @@ class SourceCode(Program):
 
         # Copy all files
         rutil.add_files(path, self.path)
+        self._code_size = sum(os.path.getsize(f) for f in rutil.list_files_recursive(self.path))
         if include_dir is not None:
             include_dir = os.path.join(include_dir, self.language.lang_id)
             if os.path.isdir(include_dir):
@@ -77,7 +78,7 @@ class SourceCode(Program):
         self.binary = os.path.join(self.path, 'run')
 
     def code_size(self) -> int:
-        return sum(os.path.getsize(x) for x in self.src)
+        return self._code_size
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Compile the source code.


### PR DESCRIPTION
We had two old bugs in how we computed the size of a submission (which we use to give an error when an example submission is larger than the submission size limit).

Firstly, we included any include files in the computation (which has tripped us up a few times in the past). Secondly, we only counted files we would list on the command line (so, e.g.,`*.h` was not counted).

This PR makes is so that the size of a submission is the size of the files in the submission - nothing more, nothing less. :)