### PR TITLE
Cancel queued up work on ctrl-c #425

### DIFF
--- a/problemtools/context.py
+++ b/problemtools/context.py
@@ -32,5 +32,9 @@ class Context:
         assert self.executor
         self._background_work.append(self.executor.submit(job, *args, **kwargs))
 
+    def cancel_background_work(self) -> None:
+        for future in self._background_work:
+            future.cancel()
+
     def wait_for_background_work(self) -> None:
         concurrent.futures.wait(self._background_work)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1485,6 +1485,11 @@ class Problem(ProblemAspect):
                     item.check(context)
         except VerifyError:
             pass
+        except KeyboardInterrupt:
+            # In multithreaded runs, we can queue up large chunks of work. If the
+            # user presses ctrl-c, we want to cancel that to exit quickly.
+            context.cancel_background_work()
+            raise
         finally:
             # Wait for background work to finish before performing an rmtree on
             # the directory tree it uses.


### PR DESCRIPTION
Improve the behavior of ctrl-c when running verifyproblem multithreaded. Now, if we're exiting due to a `KeyboardInterrupt`, we cancel all queued up futures, preventing new jobs from starting.

There is a potential for a race still if a thread starts a new run before we cancel (all running processes will get a SIGINT from the ctrl-c, so running jobs will die). I was completely unable to hit that race, so I kept my PR as simple as possible (Fixing it properly is painful. I originally had a heuristic which did a SIGTERM to all child processes, but removed it to simplify the PR when I saw that it seemed reliable enough without it).

Fixes #425