### PR TITLE
Check output limit when running submissions. Allow graders to output OLE and MLE.

### DIFF
--- a/problemtools/judge/grade.py
+++ b/problemtools/judge/grade.py
@@ -10,7 +10,7 @@ from ..diagnostics import Diagnostics
 from ..run import Program
 from .result import SubmissionResult, Verdict
 
-_GRADER_OUTPUT_RE = re.compile(r'^((AC)|(WA)|(TLE)|(RTE)|(JE))\s+-?[0-9.]+\s*$')
+_GRADER_OUTPUT_RE = re.compile(r'^((AC)|(WA)|(TLE)|(RTE)|(MLE)|(OLE)|(JE))\s+-?[0-9.]+\s*$')
 
 
 def grade_group(

--- a/problemtools/judge/validate.py
+++ b/problemtools/judge/validate.py
@@ -89,6 +89,10 @@ def _validate_output(
     val_timelim = metadata.limits.validation_time
     val_memlim = metadata.limits.validation_memory
 
+    output_size = os.path.getsize(submission_output) / 1024.0 / 1024.0
+    if output_size > metadata.limits.output:
+        return SubmissionResult('OLE', reason=f'output ({output_size:.1f} Mb) exceeds output limit ({metadata.limits.output} Mb)')
+
     if not output_validator.compile()[0]:
         return SubmissionResult('JE', reason=f'output validator {output_validator} failed to compile')
     val_stdout = execution_dir / 'val_stdout'


### PR DESCRIPTION
Checks the output file size of submissions, giving OLE if it exceeds the output limit, fixing #434 

To support this, we allow graders to output OLE (and MLE), even if those are currently missing from the spec https://github.com/Kattis/problem-package-format/issues/586
