### PR TITLE
Support default include files + minor `run` clean-up

### DIFF
--- a/problemtools/model/includes.py
+++ b/problemtools/model/includes.py
@@ -58,15 +58,14 @@ def load_includes(probdir: Path, language_config: Languages) -> Includes:
 
 
 def _load_language_includes(lang_dir: Path, language: Language | None) -> LanguageIncludes:
-    files = [
-        IncludeFile(path=path.relative_to(lang_dir), data=path.read_bytes())
-        for path in sorted(p for p in lang_dir.rglob('*') if p.is_file())
-    ]
+    paths = sorted(p for p in lang_dir.rglob('*') if p.is_file())
+    files = [IncludeFile(path=path.relative_to(lang_dir), data=path.read_bytes()) for path in paths]
 
     mainfile = None
     if language is not None:
-        candidates = language.mainfile_candidates([f.path for f in files])
+        source_files = language.get_source_files(paths)
+        candidates = language.mainfile_candidates(source_files)
         if candidates:
-            mainfile = str(candidates[0])
+            mainfile = str(Path(candidates[0]).relative_to(lang_dir))
 
     return LanguageIncludes(mainfile=mainfile, files=files)

--- a/problemtools/model/includes.py
+++ b/problemtools/model/includes.py
@@ -7,7 +7,7 @@ from ..languages import Language, Languages
 DEFAULT_LANGUAGE = 'default'
 
 
-@dataclass
+@dataclass(frozen=True)
 class IncludeFile:
     """A single include file.
 
@@ -19,13 +19,13 @@ class IncludeFile:
     data: bytes
 
 
-@dataclass
+@dataclass(frozen=True)
 class LanguageIncludes:
     mainfile: str | None = None
     files: list[IncludeFile] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Includes:
     """All include files for a problem, keyed by language ID.
 

--- a/problemtools/model/includes.py
+++ b/problemtools/model/includes.py
@@ -34,6 +34,15 @@ class Includes:
 
     languages: dict[str, LanguageIncludes] = field(default_factory=dict)
 
+    def get_includes_for_language(self, language: str) -> LanguageIncludes:
+        """All includes relevant for `language`: the files registered for
+        DEFAULT_LANGUAGE (which apply to every language) plus those registered
+        for `language` itself, with the mainfile taken from `language`.
+        """
+        default_includes = self.languages.get(DEFAULT_LANGUAGE, LanguageIncludes())
+        lang_includes = self.languages.get(language, LanguageIncludes())
+        return LanguageIncludes(mainfile=lang_includes.mainfile, files=default_includes.files + lang_includes.files)
+
 
 def load_includes(probdir: Path, language_config: Languages) -> Includes:
     include_dir = probdir / 'include'

--- a/problemtools/run/__init__.py
+++ b/problemtools/run/__init__.py
@@ -4,6 +4,8 @@ Problemtools.
 
 import os
 
+from ..languages import Languages
+from ..model import Includes
 from . import rutil
 from .buildrun import BuildRun
 from .checktestdata import Checktestdata
@@ -13,8 +15,6 @@ from .source import SourceCode
 from .tools import get_tool as get_tool
 from .tools import get_tool_path as get_tool_path
 from .viva import Viva
-from ..languages import Languages
-from ..model import Includes
 
 
 def find_programs(

--- a/problemtools/run/__init__.py
+++ b/problemtools/run/__init__.py
@@ -14,13 +14,14 @@ from .tools import get_tool as get_tool
 from .tools import get_tool_path as get_tool_path
 from .viva import Viva
 from ..languages import Languages
+from ..model import Includes
 
 
 def find_programs(
     path: str,
     language_config: Languages,
     work_dir: str,
-    include_dir: str | None = None,
+    includes: Includes = Includes(),
     allow_validation_script: bool = False,
 ) -> list[Program]:
     """Find all programs in a directory.
@@ -34,11 +35,9 @@ def find_programs(
 
         work_dir: temp directory in which to compile programs etc
 
-        include_dir: directory containing language-specific
-            include files to use.  If a program is found with source
-            code for language ID <foo> (e.g. <foo>="cpp"), then the
-            files in include_dir/<foo>/ will be copied into the
-            work_dir along with the source file(s).
+        includes: include files to add to programs found, resolved
+            per-program based on its detected language (see
+            Includes.get_includes_for_language).
 
         allow_validation_script: if true, also looks for
             validation scripts in the Checktestdata and VIVA formats.
@@ -56,7 +55,7 @@ def find_programs(
             fullpath,
             language_config=language_config,
             work_dir=work_dir,
-            include_dir=include_dir,
+            includes=includes,
             allow_validation_script=allow_validation_script,
         )
         if run is not None:
@@ -68,7 +67,7 @@ def get_program(
     path: str,
     language_config: Languages,
     work_dir: str,
-    include_dir: str | None = None,
+    includes: Includes = Includes(),
     allow_validation_script: bool = False,
 ) -> Program | None:
     """Get a Program object for a program
@@ -84,11 +83,9 @@ def get_program(
 
         work_dir: temp directory in which to compile programs etc
 
-        include_dir: directory containing language-specific
-            include files to use.  If a program is found with source
-            code for language ID <foo> (e.g. <foo>="cpp"), then the
-            files in include_dir/<foo>/ will be copied into the
-            work_dir along with the source file(s).
+        includes: include files to add to the program, resolved per
+            the program's detected language (see
+            Includes.get_includes_for_language).
 
         allow_validation_script: if true, also looks for
             validation scripts in the Checktestdata and VIVA formats.
@@ -114,5 +111,5 @@ def get_program(
 
     lang = language_config.detect_language(files)
     if lang is not None:
-        return SourceCode(path, lang, work_dir=work_dir, include_dir=include_dir)
+        return SourceCode(path, lang, work_dir=work_dir, includes=includes.get_includes_for_language(lang.lang_id))
     return None

--- a/problemtools/run/__init__.py
+++ b/problemtools/run/__init__.py
@@ -3,7 +3,6 @@ Problemtools.
 """
 
 import os
-import re
 
 from . import rutil
 from .buildrun import BuildRun
@@ -14,33 +13,34 @@ from .source import SourceCode
 from .tools import get_tool as get_tool
 from .tools import get_tool_path as get_tool_path
 from .viva import Viva
+from ..languages import Languages
 
 
 def find_programs(
-    path, pattern='.*', language_config=None, work_dir=None, include_dir=None, allow_validation_script=False
+    path: str,
+    language_config: Languages,
+    work_dir: str,
+    include_dir: str | None = None,
+    allow_validation_script: bool = False,
 ) -> list[Program]:
     """Find all programs in a directory.
 
     Args:
-        path (str): directory in which to search for programs
+        path: directory in which to search for programs
 
-        pattern (str): only files/subdirectories in path whose base
-            name matches this regular expression will be included.
+        language_config: language config, used for auto-detecting
+            programming language of source code and providing info
+            on how to compile and run the source code.
 
-        language_config (problemtools.languages.Languages):
-            language config, used for auto-detecting programming
-            language of source code and providing info on how to
-            compile and run the source code.
+        work_dir: temp directory in which to compile programs etc
 
-        work_dir (str): temp directory in which to compile programs etc
-
-        include_dir (str): directory containing language-specific
+        include_dir: directory containing language-specific
             include files to use.  If a program is found with source
             code for language ID <foo> (e.g. <foo>="cpp"), then the
             files in include_dir/<foo>/ will be copied into the
             work_dir along with the source file(s).
 
-        allow_validation_script (bool): if true, also looks for
+        allow_validation_script: if true, also looks for
             validation scripts in the Checktestdata and VIVA formats.
 
     Returns:
@@ -51,43 +51,46 @@ def find_programs(
         return []
     ret = []
     for name in sorted(os.listdir(path)):
-        if re.match(pattern, name):
-            fullpath = os.path.join(path, name)
-            run = get_program(
-                fullpath,
-                language_config=language_config,
-                work_dir=work_dir,
-                include_dir=include_dir,
-                allow_validation_script=allow_validation_script,
-            )
-            if run is not None:
-                ret.append(run)
+        fullpath = os.path.join(path, name)
+        run = get_program(
+            fullpath,
+            language_config=language_config,
+            work_dir=work_dir,
+            include_dir=include_dir,
+            allow_validation_script=allow_validation_script,
+        )
+        if run is not None:
+            ret.append(run)
     return ret
 
 
-def get_program(path, language_config=None, work_dir=None, include_dir=None, allow_validation_script=False) -> Program | None:
+def get_program(
+    path: str,
+    language_config: Languages,
+    work_dir: str,
+    include_dir: str | None = None,
+    allow_validation_script: bool = False,
+) -> Program | None:
     """Get a Program object for a program
 
     Args:
-
-        path (str): path of program.  Can be either a single file or a
+        path: path of program.  Can be either a single file or a
             directory (in which case the program is considered to
             consist of all files and subdirectories in the path).
 
-        language_config (problemtools.languages.Languages):
-            language config, used for auto-detecting programming
-            language of source code and providing info on how to
-            compile and run the source code.
+        language_config: language config, used for auto-detecting
+            programming language of source code and providing info
+            on how to compile and run the source code.
 
-        work_dir (str): temp directory in which to compile programs etc
+        work_dir: temp directory in which to compile programs etc
 
-        include_dir (str): directory containing language-specific
+        include_dir: directory containing language-specific
             include files to use.  If a program is found with source
             code for language ID <foo> (e.g. <foo>="cpp"), then the
             files in include_dir/<foo>/ will be copied into the
             work_dir along with the source file(s).
 
-        allow_validation_script (bool): if true, also looks for
+        allow_validation_script: if true, also looks for
             validation scripts in the Checktestdata and VIVA formats.
 
     Returns:
@@ -109,8 +112,7 @@ def get_program(path, language_config=None, work_dir=None, include_dir=None, all
             return BuildRun(path, work_dir)
         files = rutil.list_files_recursive(path)
 
-    if language_config is not None:
-        lang = language_config.detect_language(files)
-        if lang is not None:
-            return SourceCode(path, lang, work_dir=work_dir, include_dir=include_dir)
+    lang = language_config.detect_language(files)
+    if lang is not None:
+        return SourceCode(path, lang, work_dir=work_dir, include_dir=include_dir)
     return None

--- a/problemtools/run/buildrun.py
+++ b/problemtools/run/buildrun.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__file__)
 class BuildRun(Program):
     """Class for build/run-script program."""
 
-    def __init__(self, path, work_dir=None, include_dir=None):
+    def __init__(self, path, work_dir=None):
         """Instantiate BuildRun object.
 
         Args:
@@ -43,10 +43,7 @@ class BuildRun(Program):
             os.makedirs(self.path)
 
         rutil.add_files(path, self.path)
-        if include_dir is not None and os.path.isdir(include_dir):
-            rutil.add_files(include_dir, self.path)
 
-        # Check for existence of build script after copying include_dir, since that could contain the script
         build = os.path.join(self.path, 'build')
         if not os.path.isfile(build):
             raise ProgramError('%s does not have a build script' % path)

--- a/problemtools/run/buildrun.py
+++ b/problemtools/run/buildrun.py
@@ -17,21 +17,17 @@ log = logging.getLogger(__file__)
 class BuildRun(Program):
     """Class for build/run-script program."""
 
-    def __init__(self, path, work_dir=None):
+    def __init__(self, path: str, work_dir: str):
         """Instantiate BuildRun object.
 
         Args:
-            path (str): directory containing the build script.
-            work_dir (str): name of temp directory in which to run the
-                scripts (if None, will make new temp directory).
+            path: directory containing the build script.
+            work_dir: name of temp directory in which to run the scripts.
         """
         super().__init__()
 
         if not os.path.isdir(path):
             raise ProgramError('%s is not a directory' % path)
-
-        if work_dir is None:
-            work_dir = tempfile.mkdtemp()
 
         if path[-1] == '/':
             path = path[:-1]

--- a/problemtools/run/checktestdata.py
+++ b/problemtools/run/checktestdata.py
@@ -11,11 +11,11 @@ from .executable import Executable
 class Checktestdata(Executable):
     """Wrapper class for running Checktestdata scripts."""
 
-    def __init__(self, path):
+    def __init__(self, path: str):
         """Create a Checktestdata wrapper.
 
         Args:
-            path (str): path to .ctd source file
+            path: path to .ctd source file
         """
         super().__init__(sys.executable, args=['-m', 'checktestdata', path])
 

--- a/problemtools/run/executable.py
+++ b/problemtools/run/executable.py
@@ -11,11 +11,11 @@ from .program import Program
 class Executable(Program):
     """Class for executable files."""
 
-    def __init__(self, path, args=None):
+    def __init__(self, path: str, args: list[str] | None = None):
         """Instantiate executable object.
 
         Args:
-            path (str): path to the executable file.  Must be a file,
+            path: path to the executable file.  Must be a file,
                 and must be executable.
             args: list of additional command line arguments that
                 should be passed to the program every time it is executed.

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -18,7 +18,6 @@ class Program(ABC):
 
     def __init__(self) -> None:
         self.path: str = ''
-        self.runtime = 0
         self._compile_lock = threading.Lock()
         self._compile_result: tuple[bool, str | None] | None = None
 
@@ -54,8 +53,6 @@ class Program(ABC):
             memlim = None
 
         status, runtime = self.__run_wait(runcmd + args, infile, outfile, errfile, timelim, memlim, work_dir)
-
-        self.runtime = max(self.runtime, runtime)
 
         return status, runtime
 

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -11,6 +11,7 @@ import tempfile
 from . import rutil
 from .errors import ProgramError
 from .program import Program
+from ..languages import Language
 from ..model import LanguageIncludes
 
 log = logging.getLogger(__name__)
@@ -19,20 +20,19 @@ log = logging.getLogger(__name__)
 class SourceCode(Program):
     """Class representing a program provided by source code."""
 
-    def __init__(self, path, language, work_dir=None, includes: LanguageIncludes = LanguageIncludes()):
+    def __init__(self, path: str, language: Language, work_dir: str, includes: LanguageIncludes):
         """Instantiate SourceCode object
 
         Args:
-            path (str): path of source code.  Can be either a single
+            path: path of source code.  Can be either a single
                 file or a directory (in which case the program is
                 considered to consist of all files and subdirectories
                 in the path).
 
-            language (problemtools.Language): language definition for
-                the programming language of the code.
+            language: language definition for the programming
+                language of the code.
 
-            work_dir (str): temp directory in which to compile programs
-                etc
+            work_dir: temp directory in which to compile programs etc
 
             includes: include files to add alongside the source
                 file(s), already resolved for this program's language
@@ -48,8 +48,6 @@ class SourceCode(Program):
         self.language = language
 
         # Set up work-space
-        if work_dir is None:
-            work_dir = tempfile.mkdtemp()
         self.path = os.path.join(work_dir, self.name)
         if os.path.exists(self.path):
             self.path = tempfile.mkdtemp(prefix='%s-' % self.name, dir=work_dir)
@@ -73,7 +71,7 @@ class SourceCode(Program):
             self.mainfile = os.path.join(self.path, includes.mainfile)
         else:
             candidates = self.language.mainfile_candidates(self.src)
-            self.mainfile = candidates[0] if candidates else self.src[0]
+            self.mainfile = str(candidates[0]) if candidates else self.src[0]
 
         self.mainclass = os.path.splitext(os.path.basename(self.mainfile))[0]
         self.Mainclass = self.mainclass[0].upper() + self.mainclass[1:]
@@ -108,6 +106,7 @@ class SourceCode(Program):
             return (False, err.output.decode('utf8', 'replace'))
 
     def get_compilecmd(self) -> list[str]:
+        assert self.language.compile is not None, 'get_compilecmd called for a language with no compile command'
         return shlex.split(self.language.compile.format(**self.__get_substitution()))
 
     def get_runcmd(self, cwd=None, memlim=1024):
@@ -126,6 +125,7 @@ class SourceCode(Program):
             subs['path'] = os.path.relpath(subs['path'], cwd)
             subs['binary'] = os.path.relpath(subs['binary'], cwd)
             subs['mainfile'] = os.path.relpath(subs['mainfile'], cwd)
+        assert self.language.run is not None, 'Language.__check() guarantees run is always set'
         return shlex.split(self.language.run.format(**subs))
 
     def should_skip_memory_rlimit(self) -> bool:

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -11,6 +11,7 @@ import tempfile
 from . import rutil
 from .errors import ProgramError
 from .program import Program
+from ..model import LanguageIncludes
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +19,7 @@ log = logging.getLogger(__name__)
 class SourceCode(Program):
     """Class representing a program provided by source code."""
 
-    def __init__(self, path, language, work_dir=None, include_dir=None):
+    def __init__(self, path, language, work_dir=None, includes: LanguageIncludes = LanguageIncludes()):
         """Instantiate SourceCode object
 
         Args:
@@ -33,11 +34,11 @@ class SourceCode(Program):
             work_dir (str): temp directory in which to compile programs
                 etc
 
-            include_dir (str): directory containing language-specific
-                include files to use.  If a program is found with
-                source code for language ID <foo> (e.g. <foo>="cpp"),
-                then the files in include_dir/<foo>/ will be copied
-                into the work_dir along with the source file(s).
+            includes: include files to add alongside the source
+                file(s), already resolved for this program's language
+                (see Includes.get_includes_for_language). If it specifies
+                a mainfile, that takes precedence over the one we would
+                otherwise have detected.
         """
         super().__init__()
 
@@ -58,17 +59,21 @@ class SourceCode(Program):
         # Copy all files
         rutil.add_files(path, self.path)
         self._code_size = sum(os.path.getsize(f) for f in rutil.list_files_recursive(self.path))
-        if include_dir is not None:
-            include_dir = os.path.join(include_dir, self.language.lang_id)
-            if os.path.isdir(include_dir):
-                rutil.add_files(include_dir, self.path)
+        for include_file in includes.files:
+            dest = os.path.join(self.path, include_file.path)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, 'wb') as f:
+                f.write(include_file.data)
 
         self.src = sorted(self.language.get_source_files(rutil.list_files_recursive(self.path)))
         if len(self.src) == 0:
             raise ProgramError('No source files found for language %s in %s' % (self.language.lang_id, self.name))
 
-        candidates = self.language.mainfile_candidates(self.src)
-        self.mainfile = candidates[0] if candidates else self.src[0]
+        if includes.mainfile is not None:
+            self.mainfile = os.path.join(self.path, includes.mainfile)
+        else:
+            candidates = self.language.mainfile_candidates(self.src)
+            self.mainfile = candidates[0] if candidates else self.src[0]
 
         self.mainclass = os.path.splitext(os.path.basename(self.mainfile))[0]
         self.Mainclass = self.mainclass[0].upper() + self.mainclass[1:]

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -8,11 +8,11 @@ import shlex
 import subprocess
 import tempfile
 
+from ..languages import Language
+from ..model import LanguageIncludes
 from . import rutil
 from .errors import ProgramError
 from .program import Program
-from ..languages import Language
-from ..model import LanguageIncludes
 
 log = logging.getLogger(__name__)
 

--- a/problemtools/run/viva.py
+++ b/problemtools/run/viva.py
@@ -14,11 +14,11 @@ class Viva(Executable):
 
     _VIVA_PATH = get_tool_path('viva.sh')
 
-    def __init__(self, path):
+    def __init__(self, path: str):
         """Create a VIVA wrapper.
 
         Args:
-            path (str): path to .viva source file
+            path: path to .viva source file
         """
         if Viva._VIVA_PATH is None:
             raise ProgramError('Could not locate the VIVA program to run %s' % path)

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1091,7 +1091,7 @@ class Submissions(ProblemPart):
                 os.path.join(srcdir, verdict[1]),
                 language_config=self.problem.language_config,
                 work_dir=self.problem.tmpdir,
-                include_dir=os.path.join(self.problem.probdir, 'include'),
+                includes=self.problem.includes.includes,
             )
         return {}
 
@@ -1440,6 +1440,7 @@ class Problem(ProblemAspect):
         self.graders = Graders(self)
         self.testdata = TestCaseGroup(self, os.path.join(self.probdir, 'data'))
         self.includes = Includes(self)
+        # Submissions.setup() reads self.includes.includes, so includes must be loaded first.
         self.submissions = Submissions(self)
         self.loaded = True
 


### PR DESCRIPTION
Adds support for "default" include files (using parsed model.Includes instead of having find_programs duplicate that logic).

Also a bit of clean-up of  `run`:

- Fix a bug in mainfile detection in model - we did not filter on source files.
- Adds type annotations to constructors in `run` (they were previously in comments). This makes `mypy` find new things, so I stopped there to avoid blowing up this PR.
- Stricter parameter lists for constructors and methods in `run` - e.g., you must now specify a workdir (instead of the classes subtly just dropping a tmp dir somewhere if you forgot).

Fixes #444 