### PR TITLE
Change semantics of shebang in language configuration

### DIFF
--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -15,8 +15,15 @@
 #   files: String, space-separated glob patterns indicating what files
 #          are considered source files.
 #
-#   shebang: Optional, string, for language detection only.  See
-#            semantics under "language detection" below.
+#   shebang_files: Optional, string, space-separated glob patterns, for
+#                   language detection only.  Must be given together
+#                   with "shebang".  See semantics under "language
+#                   detection" below.
+#
+#   shebang: Optional, string, regular expression, for language
+#            detection only.  Must be given together with
+#            "shebang_files".  See semantics under "language detection"
+#            below.
 #
 #   compile: Optional, string, command to compile or syntax-check the
 #            source code.
@@ -31,14 +38,24 @@
 #
 # 1. For each language, a file included in the program is considered
 #    to be a source file if its name matches the "files" glob for the
-#    language.  If the language specifies a "shebang" entry, the
-#    first line of the file *must additionally* match the shebang.
+#    language.  Once a program's language has been settled, this is
+#    the full set of source files for the program -- "shebang_files"
+#    and "shebang" (see below) play no further part.
 #
-# 2. For each language, count how many files in the program are source
-#    files for that language.
+# 2. For the purposes of auto-detection only, a source file additionally
+#    counts as *evidence* for a language if either it doesn't match the
+#    language's "shebang_files" glob, or its first line matches
+#    "shebang".  This lets a language claim only some of the files
+#    matching its "files" glob as its own during detection, e.g. to
+#    distinguish Python 2 from Python 3 based on a "#!...python2"
+#    shebang while still treating shebang-less helper files as
+#    belonging to whichever language wins.
 #
-# 3. The language of the program is the one under which the program
-#    has the maximum number of source files.  In case of ties, the
+# 3. For each language, count how many files in the program count as
+#    evidence for that language (per step 2).
+#
+# 4. The language of the program is the one under which the program
+#    has the maximum number of matching files.  In case of ties, the
 #    language that has the highest priority takes precedence.
 #
 #
@@ -207,11 +224,16 @@ prolog:
     compile: '/usr/bin/swipl -O -q -g main -t halt -o {binary} -c {files}'
     run: '{binary}'
 
-# Python2 with shebang comes before default python3.
-python2_with_shebang:
+# *.py2 files are unconditionally Python 2. *.py files are only counted
+# as Python 2 (over Python 3) when they carry a python2 shebang; a *.py
+# file without one is only evidence for python3. Priority is higher than
+# python3's so that ties (i.e. every *.py file in the program has the
+# shebang) resolve to python2.
+python2:
     name: 'Python 2 (w/PyPy)'
     priority: 860
     files: '*.py *.py2'
+    shebang_files: '*.py'
     shebang: '^#!.*python2\b'
     compile: '/usr/bin/pypy -m py_compile {files}'
     run: '/usr/bin/pypy "{mainfile}"'
@@ -222,14 +244,6 @@ python3:
     files: '*.py *.py3'
     compile: '/usr/bin/pypy3 -m py_compile {files}'
     run: '/usr/bin/pypy3 "{mainfile}"'
-
-# Python2 without shebang comes after python3.
-python2:
-    name: 'Python 2 (w/PyPy)'
-    priority: 840
-    files: '*.py2'
-    compile: '/usr/bin/pypy -m py_compile {files}'
-    run: '/usr/bin/pypy "{mainfile}"'
 
 ruby:
     name: 'Ruby'

--- a/problemtools/languages.py
+++ b/problemtools/languages.py
@@ -20,7 +20,7 @@ class Language:
     Class representing a single language.
     """
 
-    __KEYS = ['name', 'priority', 'files', 'shebang', 'compile', 'run']
+    __KEYS = ['name', 'priority', 'files', 'shebang', 'shebang_files', 'compile', 'run']
     __VARIABLES = ['path', 'files', 'binary', 'mainfile', 'mainclass', 'Mainclass', 'memlim']
     __MAINFILE_RE = re.compile(r'^main\.', re.IGNORECASE)
 
@@ -39,6 +39,7 @@ class Language:
         self.priority = None
         self.files = None
         self.shebang = None
+        self.shebang_files = None
         self.compile = None
         self.run = None
         self.update(lang_spec)
@@ -47,17 +48,29 @@ class Language:
         """Given a list of files, determine which ones would be considered
         source files for the language.
 
+        This method only looks at file names, not at file contents, so it
+        works even if the files don't exist or aren't readable.
+
         Args:
             file_list (list of str): list of file names
         """
-        return [
-            file_name
-            for file_name in file_list
-            if (
-                any(fnmatch.fnmatch(file_name, glob) for glob in self.files)  # type: ignore[union-attr]
-                and self.__matches_shebang(file_name)
-            )
-        ]
+        return [file_name for file_name in file_list if any(fnmatch.fnmatch(file_name, glob) for glob in self.files)]  # type: ignore[union-attr]
+
+    def get_source_files_for_detection(self, file_list):
+        """Given a list of files, determine which ones count as positive
+        evidence that a program is written in this language, for use when
+        auto-detecting a program's language (see Languages.detect_language).
+
+        This is a subset of get_source_files(file_list): files matched by
+        shebang_files must additionally have their first line match
+        shebang. Unlike get_source_files, this method needs to open and
+        read each candidate file, so all files in file_list must exist and
+        be readable.
+
+        Args:
+            file_list (list of str): list of file names
+        """
+        return [file_name for file_name in self.get_source_files(file_list) if self.__passes_shebang_gate(file_name)]
 
     def mainfile_candidates(self, files: list[str | Path]) -> list[str | Path]:
         """Given a list of files, determine which ones would be considered
@@ -96,9 +109,9 @@ class Language:
             if key == 'shebang':
                 # Compile shebang RE
                 self.shebang = re.compile(value)
-            elif key == 'files':
+            elif key in ('files', 'shebang_files'):
                 # Split glob patterns
-                self.files = value.split()
+                self.__dict__[key] = value.split()
             else:
                 # Other keys, just copy the value
                 self.__dict__[key] = value
@@ -119,6 +132,8 @@ class Language:
             raise LanguageConfigError(f'Language {self.lang_id} has no files glob')
         if self.run is None:
             raise LanguageConfigError(f'Language {self.lang_id} has no run command')
+        if (self.shebang is None) != (self.shebang_files is None):
+            raise LanguageConfigError(f'Language {self.lang_id} must specify both "shebang" and "shebang_files", or neither')
 
         # Check that all variables appearing are valid
         variables = Language.__variables_in_command(self.run)
@@ -140,13 +155,16 @@ class Language:
         formatter = string.Formatter()
         return set(field for _, field, _, _ in formatter.parse(cmd) if field is not None)
 
-    def __matches_shebang(self, filename):
-        """Check if a file matches the shebang rule for the language."""
-        if self.shebang is None:
+    def __passes_shebang_gate(self, filename):
+        """Check if a file matched by shebang_files also matches shebang.
+        Files not matched by shebang_files are unaffected by the gate."""
+        if self.shebang_files is None:
+            return True
+        if not any(fnmatch.fnmatch(filename, glob) for glob in self.shebang_files):
             return True
         with open(filename, 'r') as f_in:
             shebang_line = f_in.readline()
-        return self.shebang.search(shebang_line) is not None
+        return self.shebang.search(shebang_line) is not None  # type: ignore[union-attr]
 
 
 class Languages:
@@ -178,7 +196,7 @@ class Languages:
         src: list[str] = []
         prio = 1e99
         for lang in self.languages.values():
-            lang_src = lang.get_source_files(file_list)
+            lang_src = lang.get_source_files_for_detection(file_list)
             if (len(lang_src), lang.priority) > (len(src), prio):
                 result = lang
                 src = lang_src

--- a/tests/languages_examples/py2helper.py2
+++ b/tests/languages_examples/py2helper.py2
@@ -1,0 +1,2 @@
+def helper():
+    pass

--- a/tests/languages_examples/py2main.py
+++ b/tests/languages_examples/py2main.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python2
+print('main')

--- a/tests/languages_examples/py2nosheb.py
+++ b/tests/languages_examples/py2nosheb.py
@@ -1,0 +1,2 @@
+def other_helper():
+    pass

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -14,6 +14,7 @@ class Language_test(TestCase):
             'name': 'A Language',
             'priority': 100,
             'files': '*.foo *.bar',
+            'shebang_files': '*.foo',
             'shebang': '.*',
             'compile': 'echo {path} {files} {binary}',
             'run': '{binary} {memlim}',
@@ -104,6 +105,7 @@ class Language_test(TestCase):
     def test_without_shebang(self):
         vals = self.__language_dict()
         del vals['shebang']
+        del vals['shebang_files']
         languages.Language('id', vals)
 
     def test_invalid_shebang(self):
@@ -111,6 +113,36 @@ class Language_test(TestCase):
         vals['shebang'] = '(Not an RE'
         with pytest.raises(re.error):
             languages.Language('id', vals)
+
+    def test_shebang_requires_shebang_files(self):
+        vals = self.__language_dict()
+        del vals['shebang_files']
+        with pytest.raises(languages.LanguageConfigError):
+            languages.Language('id', vals)
+
+    def test_shebang_files_requires_shebang(self):
+        vals = self.__language_dict()
+        del vals['shebang']
+        with pytest.raises(languages.LanguageConfigError):
+            languages.Language('id', vals)
+
+    def test_invalid_shebang_files(self):
+        vals = self.__language_dict()
+        vals['shebang_files'] = ['*.foo', '*.bar']
+        with pytest.raises(languages.LanguageConfigError):
+            languages.Language('id', vals)
+
+    def test_get_source_files_does_not_require_readable_files(self):
+        """get_source_files only inspects file names -- unlike
+        get_source_files_for_detection, it must work even for files that
+        don't exist, since it's used on a program whose language is
+        already known."""
+        lang = languages.Language('id', self.__language_dict())
+        missing = '/nonexistent/path/does_not_exist.foo'
+
+        assert lang.get_source_files([missing]) == [missing]
+        with pytest.raises(OSError):
+            lang.get_source_files_for_detection([missing])
 
     def test_without_compile(self):
         vals = self.__language_dict()
@@ -245,7 +277,14 @@ class Languages_test(TestCase):
 
         zoo = {
             'zoo': {'name': 'Zoo', 'priority': 10, 'files': '*.zoo', 'run': '{binary}'},
-            'zoork': {'name': 'Zoork', 'priority': 20, 'files': '*.zoo', 'shebang': '>.*Zoork', 'run': '{binary}'},
+            'zoork': {
+                'name': 'Zoork',
+                'priority': 20,
+                'files': '*.zoo',
+                'shebang_files': '*.zoo',
+                'shebang': '>.*Zoork',
+                'run': '{binary}',
+            },
             'zoopp': {'name': 'Zoo++', 'priority': 0, 'files': '*.zoo *.zpp', 'run': '{binary}'},
         }
 
@@ -259,3 +298,40 @@ class Languages_test(TestCase):
 
         lang = langs.detect_language([examples_path(x) for x in ['src2.zoo', 'src3.zpp']])
         assert lang.lang_id == 'zoopp'
+
+    def test_shebang_gate_only_affects_detection_not_actual_source_files(self):
+        """Regression test: once a language has won detection, a helper
+        file matching its "files" glob must not be dropped just because it
+        individually lacks the shebang that broke the tie against another
+        language (see py2nosheb.py below)."""
+        langs = languages.Languages()
+        langs.update(
+            {
+                'py2': {
+                    'name': 'Python 2',
+                    'priority': 60,
+                    'files': '*.py *.py2',
+                    'shebang_files': '*.py',
+                    'shebang': r'^#!.*python2\b',
+                    'run': '{mainfile}',
+                },
+                'py3': {
+                    'name': 'Python 3',
+                    'priority': 50,
+                    'files': '*.py *.py3',
+                    'run': '{mainfile}',
+                },
+            }
+        )
+
+        files = [examples_path(x) for x in ['py2main.py', 'py2helper.py2', 'py2nosheb.py']]
+
+        # py2 evidence: py2main.py (shebang matches) + py2helper.py2
+        # (unconditional, not gated) = 2.  py3 evidence: py2main.py +
+        # py2nosheb.py (both unconditional) = 2.  Tie -> priority decides.
+        lang = langs.detect_language(files)
+        assert lang.lang_id == 'py2'
+
+        # All three files -- including the shebang-less helper -- belong
+        # to the now-settled py2 program.
+        assert set(lang.get_source_files(files)) == set(files)


### PR DESCRIPTION
Changes the semantics of shebang handling in language detection. When specifying a shebang, one must also specify a pattern (matching a subset or all files matched by files) in which one does shebang detection.

Shebang detection now *only* applies to language detection. Once a language has been selected, all files matching `files` in that language are included (shebang or not). In particular, this means that if a program has a `foo.py` with a python2-shebang and a `main.py` without a shebang, it will now be detected as python2, with two files, `foo.py` and `main.py`, where `main.py` is the mainfile. Earlier code would have detected this as `python2_with_shebang`, with a single file, `foo.py` (which would then also end up as the mainfile).

Note that our shebang detection is not perfect, and not quite in line with the wording of the spec (which I think requires a shebang in *every* `.py` file - https://github.com/Kattis/problem-package-format/issues/591 ). In particular, if you have more `.py` files without a shebang than you do `.py` files with a python2-shebang, the language will be detected as python3 (both before and after this PR). Fixing that requires a larger rewrite, which I'm not sure is worth it (as incorrect language detection is extremely likely to be very noticable).

Fixes #457 