### PR TITLE
Default to looking for tools on PATH, rather than requiring them to be in `/usr/bin`

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,10 @@
+# We don't really use bandit ourselves, but codefactor runs it for us.
+# This config makes it less silly
+[bandit]
+# Plain directory names here (e.g. "tests") silently fail to exclude
+# anything, despite being the exact example bandit's docs uses...
+# https://bandit.readthedocs.io/en/latest/config.html#bandit-settings
+exclude = ./tests/*
+# Bandit warns about executing programs, using asserts, and also thinks
+# multi-pass is a hard-coded password...
+skips = B101,B105,B311,B404,B601,B603,B606,B607

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ problemtools' configuration:
 
 1. `languages.yaml`.  Use it to override problemtools' default
    programming language configuration.  For instance, while the
-   problemtools default is to use the PyPy `/usr/bin/pypy3`
-   interpreter for Python 3. If you prefer  CPython, you can
+   problemtools default is to use the PyPy `pypy3` interpreter
+   for Python 3. If you prefer  CPython, you can
    use the following `languages.yaml`:
 
    ```yaml

--- a/problemtools/config/languages.yaml
+++ b/problemtools/config/languages.yaml
@@ -115,84 +115,84 @@ c:
     name: 'C'
     priority: 950
     files: '*.c'
-    compile: '/usr/bin/gcc -g -O2 -std=gnu17 -static -o {binary} {files} -lm'
+    compile: 'gcc -g -O2 -std=gnu17 -static -o {binary} {files} -lm'
     run: '{binary}'
 
 cpp:
     name: 'C++'
     priority: 1000
     files: '*.cc *.C *.cpp *.cxx *.c++'
-    compile: '/usr/bin/g++ -g -O2 -std=gnu++23 -static -o {binary} {files} -lrt -Wl,--whole-archive  -lpthread -Wl,--no-whole-archive'
+    compile: 'g++ -g -O2 -std=gnu++23 -static -o {binary} {files} -lrt -Wl,--whole-archive  -lpthread -Wl,--no-whole-archive'
     run: '{binary}'
 
 csharp:
     name: 'C#'
     priority: 700
     files: '*.cs'
-    compile: '/usr/bin/mcs -out:{binary}.exe -optimize+ -r:System.Numerics {files}'
-    run: '/usr/bin/mono {binary}.exe'
+    compile: 'mcs -out:{binary}.exe -optimize+ -r:System.Numerics {files}'
+    run: 'mono {binary}.exe'
 
 cobol:
     name: 'Cobol'
     priority: 50
     files: '*.cob'
-    compile: '/usr/bin/cobc -o {binary} -g -O2 -std=default -free -x -static {files}'
+    compile: 'cobc -o {binary} -g -O2 -std=default -free -x -static {files}'
     run: '{binary}'
 
 fsharp:
     name: 'F#'
     priority: 675
     files: '*.fs'
-    compile: '/usr/bin/fsharpc --out:{binary}.exe --optimize+ -r:System.Numerics {files}'
-    run: '/usr/bin/mono {binary}.exe'
+    compile: 'fsharpc --out:{binary}.exe --optimize+ -r:System.Numerics {files}'
+    run: 'mono {binary}.exe'
 
 go:
     name: 'Go'
     priority: 400
     files: '*.go'
-    compile: '/usr/bin/gccgo -g -o {binary} -static-libgcc {files}'
+    compile: 'gccgo -g -o {binary} -static-libgcc {files}'
     run: '{binary}'
 
 haskell:
     name: 'Haskell'
     priority: 600
     files: '*.hs *.c'
-    compile: '/usr/bin/ghc -O2 -ferror-spans -threaded -rtsopts -tmpdir {path} -o {binary} {files}'
+    compile: 'ghc -O2 -ferror-spans -threaded -rtsopts -tmpdir {path} -o {binary} {files}'
     run: '{binary} +RTS -M{memlim}m -K8m -RTS'
 
 java:
     name: 'Java'
     priority: 800
     files: '*.java'
-    compile: '/usr/bin/javac -source 21 -encoding UTF-8 -sourcepath {path} -d {path} {files}'
-    run: '/usr/bin/java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xss64m -Xms{memlim}m -Xmx{memlim}m -cp {path} {mainclass}'
+    compile: 'javac -source 21 -encoding UTF-8 -sourcepath {path} -d {path} {files}'
+    run: 'java -Dfile.encoding=UTF-8 -XX:+UseSerialGC -Xss64m -Xms{memlim}m -Xmx{memlim}m -cp {path} {mainclass}'
 
 javascript:
     name: 'JavaScript'
     priority: 500
     files: '*.js'
-    compile: '/usr/bin/nodejs -c {files}'
-    run: '/usr/bin/nodejs "{mainfile}"'
+    compile: 'nodejs -c {files}'
+    run: 'nodejs "{mainfile}"'
 
 kotlin:
     name: 'Kotlin'
     priority: 250
     files: '*.kt'
-    compile: '/usr/bin/kotlinc -language-version 1.3 -d {path}/ -- {files}'
-    run: '/usr/bin/kotlin -Dfile.encoding=UTF-8 -J-XX:+UseSerialGC -J-Xss64m -J-Xms{memlim}m -J-Xmx{memlim}m -cp {path}/ {Mainclass}Kt'
+    compile: 'kotlinc -language-version 1.3 -d {path}/ -- {files}'
+    run: 'kotlin -Dfile.encoding=UTF-8 -J-XX:+UseSerialGC -J-Xss64m -J-Xms{memlim}m -J-Xmx{memlim}m -cp {path}/ {Mainclass}Kt'
 
 lisp:
     name: 'Common Lisp'
     priority: 200
     files: '*.lisp *.cl'
-    compile: '/usr/bin/sbcl --noinform --noprint --non-interactive --eval ''(if (equal (compile-file "{mainfile}") NIL) (sb-ext:exit :code 43) ())'' '
-    run: '/usr/bin/sbcl --noinform --non-interactive --load "{mainfile}"'
+    compile: 'sbcl --noinform --noprint --non-interactive --eval ''(if (equal (compile-file "{mainfile}") NIL) (sb-ext:exit :code 43) ())'' '
+    run: 'sbcl --noinform --non-interactive --load "{mainfile}"'
 
 ocaml:
     name: 'OCaml'
     priority: 375
     files: '*.ml'
-    compile: '/usr/bin/ocamlopt -o {binary} unix.cmxa str.cmxa bigarray.cmxa {files}'
+    compile: 'ocamlopt -o {binary} unix.cmxa str.cmxa bigarray.cmxa {files}'
     run: '{binary}'
 
 objectivec:
@@ -200,28 +200,28 @@ objectivec:
     priority: 300
     files: '*.m *.c'
     # The postargs for the compile command are '-lm -lobjc `gnustep-config --objc-flags` -lgnustep-base -o {binary}', edited to remove -I. and -I(home dir of user running the command), and to remove duplicate definition of GNUSTEP_BASE_LIBRARY
-    compile: '/usr/bin/gcc -O2 -std=gnu99 {files} -lm -lobjc -MMD -MP -DGNUSTEP -DGNUSTEP_BASE_LIBRARY=2 -DGNU_GUI_LIBRARY=1 -DGNU_RUNTIME=1 -fno-strict-aliasing -fexceptions -fobjc-exceptions -D_NATIVE_OBJC_EXCEPTIONS -fPIC -Wall -DGSWARN -DGSDIAGNOSE -Wno-import -g -O2 -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -fgnu-runtime -fconstant-string-class=NSConstantString -I/usr/local/include/GNUstep -I/usr/include/GNUstep -lgnustep-base -o {binary}'
+    compile: 'gcc -O2 -std=gnu99 {files} -lm -lobjc -MMD -MP -DGNUSTEP -DGNUSTEP_BASE_LIBRARY=2 -DGNU_GUI_LIBRARY=1 -DGNU_RUNTIME=1 -fno-strict-aliasing -fexceptions -fobjc-exceptions -D_NATIVE_OBJC_EXCEPTIONS -fPIC -Wall -DGSWARN -DGSDIAGNOSE -Wno-import -g -O2 -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -fgnu-runtime -fconstant-string-class=NSConstantString -I/usr/local/include/GNUstep -I/usr/include/GNUstep -lgnustep-base -o {binary}'
     run: '{binary}'
 
 pascal:
     name: 'Pascal'
     priority: 350
     files: '*.pas'
-    compile: '/usr/bin/fpc -o"{mainfile}.out" -O2 -XS -Xt "{mainfile}"'
+    compile: 'fpc -o"{mainfile}.out" -O2 -XS -Xt "{mainfile}"'
     run: '"{mainfile}.out"'
 
 php:
     name: 'PHP'
     priority: 450
     files: '*.php'
-    compile: '/usr/bin/php -n -d display_errors=stderr -d html_errors=0 -l {files}'
-    run: '/usr/bin/php -n -d display_errors=stderr -d html_errors=0 -d memory_limit={memlim}m -f "{mainfile}"'
+    compile: 'php -n -d display_errors=stderr -d html_errors=0 -l {files}'
+    run: 'php -n -d display_errors=stderr -d html_errors=0 -d memory_limit={memlim}m -f "{mainfile}"'
 
 prolog:
     name: 'Prolog'
     priority: 100
     files: '*.pl'
-    compile: '/usr/bin/swipl -O -q -g main -t halt -o {binary} -c {files}'
+    compile: 'swipl -O -q -g main -t halt -o {binary} -c {files}'
     run: '{binary}'
 
 # *.py2 files are unconditionally Python 2. *.py files are only counted
@@ -235,15 +235,15 @@ python2:
     files: '*.py *.py2'
     shebang_files: '*.py'
     shebang: '^#!.*python2\b'
-    compile: '/usr/bin/pypy -m py_compile {files}'
-    run: '/usr/bin/pypy "{mainfile}"'
+    compile: 'pypy -m py_compile {files}'
+    run: 'pypy "{mainfile}"'
 
 python3:
     name: 'Python 3 (w/PyPy3)'
     priority: 850
     files: '*.py *.py3'
-    compile: '/usr/bin/pypy3 -m py_compile {files}'
-    run: '/usr/bin/pypy3 "{mainfile}"'
+    compile: 'pypy3 -m py_compile {files}'
+    run: 'pypy3 "{mainfile}"'
 
 ruby:
     name: 'Ruby'
@@ -252,19 +252,19 @@ ruby:
     # Note that this compile command only syntax-checks the main file --
     # unfortunately the ruby -c command does not provide the option to
     # syntax-check multiple files.
-    compile: '/usr/bin/ruby -c "{mainfile}"'
-    run: '/usr/bin/ruby "{mainfile}"'
+    compile: 'ruby -c "{mainfile}"'
+    run: 'ruby "{mainfile}"'
 
 rust:
     name: 'Rust'
     priority: 575
     files: '*.rs'
-    compile: '/usr/bin/rustc -C opt-level=3 -C target-cpu=native --crate-type bin --edition 2021 {mainfile} -o {mainfile}.out'
+    compile: 'rustc -C opt-level=3 -C target-cpu=native --crate-type bin --edition 2021 {mainfile} -o {mainfile}.out'
     run: '{mainfile}.out'
 
 scala:
     name: 'Scala'
     priority: 550
     files: '*.sc *.scala'
-    compile: '/usr/bin/scalac -encoding UTF-8 -sourcepath {path} -d {path} {files}'
-    run: '/usr/bin/scala -J-Xmx{memlim}m -classpath {path} {mainclass}'
+    compile: 'scalac -encoding UTF-8 -sourcepath {path} -d {path} {files}'
+    run: 'scala -J-Xmx{memlim}m -classpath {path} {mainclass}'

--- a/problemtools/languages.py
+++ b/problemtools/languages.py
@@ -3,8 +3,11 @@ This module contains functionality for reading and using configuration
 of programming languages.
 """
 
+import dataclasses
 import fnmatch
 import re
+import shlex
+import shutil
 import string
 from collections.abc import Sequence
 from pathlib import Path
@@ -22,13 +25,24 @@ class LanguageConfigError(Exception):
     """Exception class for errors in language configuration."""
 
 
+@dataclasses.dataclass
+class CommandSubstitution:
+    """Fields that may appear in a language's "compile" and "run" command templates"""
+
+    path: str
+    files: str
+    binary: str
+    mainfile: str
+    mainclass: str
+    Mainclass: str
+    memlim: int = 1024
+
+
 class Language:
-    """
-    Class representing a single language.
-    """
+    """Class representing a single language."""
 
     __KEYS = ['name', 'priority', 'files', 'shebang', 'shebang_files', 'compile', 'run']
-    __VARIABLES = ['path', 'files', 'binary', 'mainfile', 'mainclass', 'Mainclass', 'memlim']
+    __VARIABLES = {field.name for field in dataclasses.fields(CommandSubstitution)}
     __MAINFILE_RE = re.compile(r'^main\.', re.IGNORECASE)
 
     name: str
@@ -92,6 +106,58 @@ class Language:
         """
         return [f for f in files if Language.__MAINFILE_RE.match(Path(f).name)]
 
+    def check_installed(self) -> str | None:
+        """Check that the compiler and/or runtime seem available.
+
+        Returns:
+            None on success, or human-readable message describing what's missing
+        """
+        for role, template in (('compiler', self.compile), ('runtime', self.run)):
+            if template is None:
+                continue
+            executable = Language.__literal_executable(template)
+            if executable is not None and shutil.which(executable) is None:
+                return f'{self.name}: could not find {role} "{executable}" -- is it installed and on PATH?'
+        return None
+
+    def get_compile_command(self, subs: CommandSubstitution) -> list[str] | None:
+        """Command to compile a program, or None if there is no compile step."""
+        if self.compile is None:
+            return None
+        return self.__build_command(self.compile, subs)
+
+    def get_run_command(self, subs: CommandSubstitution) -> list[str]:
+        """Command to run a program in this language."""
+        return self.__build_command(self.run, subs)
+
+    def __build_command(self, template: str, subs: CommandSubstitution) -> list[str]:
+        """Substitute metavariables into a compile/run command template,
+        producing an argv list ready to execute.
+
+        If the template's command is a literal executable name/path rather
+        than one produced by compilation, it is resolved to an absolute path.
+
+        Args:
+            template: a "compile" or "run" command template, i.e.
+                self.compile or self.run.
+            subs: substitution values for the metavariables appearing
+                in template.
+        """
+        argv = shlex.split(template.format(**dataclasses.asdict(subs)))
+        executable = Language.__literal_executable(template)
+        if executable is not None:
+            argv[0] = shutil.which(executable) or executable
+        return argv
+
+    @staticmethod
+    def __literal_executable(template: str) -> str | None:
+        """The first token of a compile/run command template, if it's a
+        literal executable name/path -- as opposed to one produced by
+        compilation, such as {binary} or "{mainfile}.out". Returns None
+        for the latter case."""
+        first = shlex.split(template)[0]
+        return None if '{' in first else first
+
     # Update is no longer really needed - we only call it from the constructor.
     # But cleaning that up doesn't simplify the code much, so we keep it around
     # for now.
@@ -151,7 +217,7 @@ class Language:
         variables = Language.__variables_in_command(self.run)
         if self.compile is not None:
             variables = variables | Language.__variables_in_command(self.compile)
-        for unknown in variables - set(Language.__VARIABLES):
+        for unknown in variables - Language.__VARIABLES:
             raise LanguageConfigError('Unknown variable "{%s}" used for language %s' % (unknown, self.lang_id))
 
         # Check for uniquely defined entry point

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -4,11 +4,10 @@ Implementation of programs provided by source code.
 
 import logging
 import os
-import shlex
 import subprocess
 import tempfile
 
-from ..languages import Language
+from ..languages import CommandSubstitution, Language
 from ..model import LanguageIncludes
 from . import rutil
 from .errors import ProgramError
@@ -88,14 +87,13 @@ class SourceCode(Program):
             (True, None) if compilation succeeded
             (False, errmsg) otherwise
         """
-        if self.language.compile is None:
+        not_installed = self.language.check_installed()
+        if not_installed is not None:
+            return (False, not_installed)
+
+        command = self.language.get_compile_command(self.__get_substitution())
+        if command is None:
             return (True, None)
-
-        command = self.get_compilecmd()
-        compiler = command[0]
-
-        if not os.path.isfile(compiler) or not os.access(compiler, os.X_OK):
-            return (False, '%s does not seem to be installed, expected to find compiler at %s' % (self.language.name, compiler))
 
         log.debug('compile command: %s', command)
 
@@ -104,10 +102,6 @@ class SourceCode(Program):
             return (True, None)
         except subprocess.CalledProcessError as err:
             return (False, err.output.decode('utf8', 'replace'))
-
-    def get_compilecmd(self) -> list[str]:
-        assert self.language.compile is not None, 'get_compilecmd called for a language with no compile command'
-        return shlex.split(self.language.compile.format(**self.__get_substitution()))
 
     def get_runcmd(self, cwd=None, memlim=1024):
         """Run command for the program.
@@ -122,10 +116,10 @@ class SourceCode(Program):
         self.compile()
         subs = self.__get_substitution(memlim)
         if cwd is not None:
-            subs['path'] = os.path.relpath(subs['path'], cwd)
-            subs['binary'] = os.path.relpath(subs['binary'], cwd)
-            subs['mainfile'] = os.path.relpath(subs['mainfile'], cwd)
-        return shlex.split(self.language.run.format(**subs))
+            subs.path = os.path.relpath(subs.path, cwd)
+            subs.binary = os.path.relpath(subs.binary, cwd)
+            subs.mainfile = os.path.relpath(subs.mainfile, cwd)
+        return self.language.get_run_command(subs)
 
     def should_skip_memory_rlimit(self) -> bool:
         """Ugly hack (see program.py for details)."""
@@ -135,13 +129,13 @@ class SourceCode(Program):
         """String representation"""
         return '%s (%s)' % (self.name, self.language.name)
 
-    def __get_substitution(self, memlim=1024):
-        return {
-            'path': self.path,
-            'files': ' '.join(self.src),
-            'memlim': memlim,
-            'mainfile': self.mainfile,
-            'mainclass': self.mainclass,
-            'Mainclass': self.Mainclass,
-            'binary': self.binary,
-        }
+    def __get_substitution(self, memlim: int = 1024) -> CommandSubstitution:
+        return CommandSubstitution(
+            path=self.path,
+            files=' '.join(self.src),
+            memlim=memlim,
+            mainfile=self.mainfile,
+            mainclass=self.mainclass,
+            Mainclass=self.Mainclass,
+            binary=self.binary,
+        )

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -409,7 +409,7 @@ class TestCaseGroup(ProblemAspect):
                 for filename in files:
                     filepath = os.path.join(root, filename)
                     if filepath.endswith('.in') and not os.path.islink(filepath):
-                        md5 = hashlib.md5()
+                        md5 = hashlib.md5(usedforsecurity=False)
                         with open(filepath, 'rb') as f:
                             for buf in iter(lambda: f.read(1024), b''):
                                 md5.update(buf)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 from unittest import TestCase
 
 import pytest
@@ -201,6 +202,97 @@ class Language_test(TestCase):
         vals['compile'] = 'echo RUN'
         with pytest.raises(languages.LanguageConfigError):
             languages.Language('id', vals)
+
+    @staticmethod
+    def __subs(**overrides):
+        values = {
+            'path': '/tmp/prog',
+            'files': 'main.foo',
+            'binary': '/tmp/prog/run',
+            'mainfile': '/tmp/prog/main.foo',
+            'mainclass': 'main',
+            'Mainclass': 'Main',
+            'memlim': 256,
+        }
+        values.update(overrides)
+        return languages.CommandSubstitution(**values)
+
+    def test_check_installed_ok(self):
+        # compile is 'echo ...' (found on PATH); run is '{binary} {memlim}',
+        # i.e. the program we just produced, so there's nothing external to
+        # check there.
+        lang = languages.Language('id', self.__language_dict())
+        assert lang.check_installed() is None
+
+    def test_check_installed_does_not_check_produced_entry_point(self):
+        # No compile step, and run is just the (self-contained) source file
+        # -- no external program is needed at all.
+        vals = self.__language_dict()
+        del vals['compile']
+        vals['run'] = '{mainfile}'
+        lang = languages.Language('id', vals)
+        assert lang.check_installed() is None
+
+    def test_check_installed_missing_compiler(self):
+        vals = self.__language_dict()
+        vals['compile'] = 'definitely_not_a_real_compiler_xyz {files} {binary}'
+        lang = languages.Language('id', vals)
+        msg = lang.check_installed()
+        assert msg is not None
+        assert 'compiler' in msg
+        assert 'definitely_not_a_real_compiler_xyz' in msg
+
+    def test_check_installed_missing_absolute_path(self):
+        vals = self.__language_dict()
+        vals['compile'] = '/nonexistent/path/to/compiler {files} {binary}'
+        lang = languages.Language('id', vals)
+        assert lang.check_installed() is not None
+
+    def test_check_installed_missing_runtime(self):
+        # No compile step -- the runtime must still be checked.
+        vals = self.__language_dict()
+        del vals['compile']
+        vals['run'] = 'definitely_not_a_real_runtime_xyz {mainfile}'
+        lang = languages.Language('id', vals)
+        msg = lang.check_installed()
+        assert msg is not None
+        assert 'runtime' in msg
+        assert 'definitely_not_a_real_runtime_xyz' in msg
+
+    def test_get_compile_command_none_without_compile_step(self):
+        vals = self.__language_dict()
+        del vals['compile']
+        lang = languages.Language('id', vals)
+        assert lang.get_compile_command(self.__subs()) is None
+
+    def test_get_compile_command_resolves_executable(self):
+        lang = languages.Language('id', self.__language_dict())
+        subs = self.__subs()
+        command = lang.get_compile_command(subs)
+        assert command == [shutil.which('echo'), subs.path, subs.files, subs.binary]
+
+    def test_get_run_command_resolves_executable(self):
+        vals = self.__language_dict()
+        vals['compile'] = 'echo {mainfile}'
+        vals['run'] = 'echo {mainfile}'
+        lang = languages.Language('id', vals)
+        subs = self.__subs()
+        assert lang.get_run_command(subs) == [shutil.which('echo'), subs.mainfile]
+
+    def test_get_run_command_leaves_produced_binary_untouched(self):
+        # run is '{binary} {memlim}' in the base dict -- the first token is
+        # the program we just compiled, not something to resolve via PATH.
+        lang = languages.Language('id', self.__language_dict())
+        subs = self.__subs()
+        assert lang.get_run_command(subs) == [subs.binary, str(subs.memlim)]
+
+    def test_get_compile_command_splits_multiple_files(self):
+        # {files} is a single space-separated string, but each file must
+        # end up as its own argument rather than one combined string.
+        lang = languages.Language('id', self.__language_dict())
+        subs = self.__subs(files='main.foo helper1.bar helper2.bar')
+        command = lang.get_compile_command(subs)
+        assert command == [shutil.which('echo'), subs.path, 'main.foo', 'helper1.bar', 'helper2.bar', subs.binary]
 
 
 __EXAMPLES_PATH = os.path.join(os.path.dirname(__file__), 'languages_examples')


### PR DESCRIPTION
This PR allows one to configure a language where the path to the compiler or interpreter is not absolute (e.g., `gcc` rather then `/usr/bin/gcc`). Such paths will be resolved using `$PATH`. This PR also changes the default config to make use of this, so now it will compile C programs using the first `gcc` in `$PATH`, rather than `/usr/bin/gcc`.

Additionally, fixes an old omission. If the runtime for a language (e.g., `java`) is missing, earlier we'd attempt to execute it and give a misleading run-time error. Now, we'll flag that as a compile error, the same way we do if the compiler is missing.

Fixes #103 