### PR TITLE
Better output on failing build-run, and type annotations/cleanup in run

### DIFF
--- a/problemtools/run/buildrun.py
+++ b/problemtools/run/buildrun.py
@@ -21,19 +21,18 @@ class BuildRun(Program):
             path: directory containing the build script.
             work_dir: name of temp directory in which to run the scripts.
         """
-        super().__init__()
-
         if not os.path.isdir(path):
             raise ProgramError(f'{path} is not a directory')
 
         if path[-1] == '/':
             path = path[:-1]
-        self.name = os.path.basename(path)
-        self.path = os.path.join(work_dir, self.name)
-        if os.path.exists(self.path):
-            self.path = tempfile.mkdtemp(prefix=f'{self.name}-', dir=work_dir)
+        name = os.path.basename(path)
+        run_path = os.path.join(work_dir, name)
+        if os.path.exists(run_path):
+            run_path = tempfile.mkdtemp(prefix=f'{name}-', dir=work_dir)
         else:
-            os.makedirs(self.path)
+            os.makedirs(run_path)
+        super().__init__(path=run_path, name=name)
 
         rutil.add_files(path, self.path)
 
@@ -42,10 +41,6 @@ class BuildRun(Program):
             raise ProgramError(f'{path} does not have a build script')
         if not os.access(build, os.X_OK):
             raise ProgramError(f'{path}/build is not executable')
-
-    def __str__(self) -> str:
-        """String representation"""
-        return f'{self.name} (build-run)'
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Run the build script."""

--- a/problemtools/run/buildrun.py
+++ b/problemtools/run/buildrun.py
@@ -2,7 +2,6 @@
 Implementation of programs provided by a directory with build/run scripts.
 """
 
-import logging
 import os
 import subprocess
 import tempfile
@@ -10,8 +9,6 @@ import tempfile
 from . import rutil
 from .errors import ProgramError
 from .program import Program
-
-log = logging.getLogger(__file__)
 
 
 class BuildRun(Program):
@@ -48,21 +45,19 @@ class BuildRun(Program):
 
     def __str__(self) -> str:
         """String representation"""
-        return '%s/' % (self.path)
+        return '%s (build-run)' % (self.name)
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Run the build script."""
-        with open(os.devnull, 'w') as devnull:
-            status = subprocess.call(['./build'], stdout=devnull, stderr=devnull, cwd=self.path)
-        run = os.path.join(self.path, 'run')
+        try:
+            subprocess.check_output(['./build'], stderr=subprocess.STDOUT, cwd=self.path)
+        except subprocess.CalledProcessError as err:
+            return (False, err.output.decode('utf8', 'replace'))
 
-        if status:
-            logging.debug('Build script failed (status %d) when compiling %s\n', status, self.name)
-            return (False, 'build script failed with exit code %d' % (status))
-        elif not os.path.isfile(run) or not os.access(run, os.X_OK):
+        run = os.path.join(self.path, 'run')
+        if not os.path.isfile(run) or not os.access(run, os.X_OK):
             return (False, 'build script did not produce an executable called "run"')
-        else:
-            return (True, None)
+        return (True, None)
 
     def get_runcmd(self, cwd=None, memlim=None) -> list[str]:
         """Run command for the program.

--- a/problemtools/run/buildrun.py
+++ b/problemtools/run/buildrun.py
@@ -14,7 +14,7 @@ from .program import Program
 class BuildRun(Program):
     """Class for build/run-script program."""
 
-    def __init__(self, path: str, work_dir: str):
+    def __init__(self, path: str, work_dir: str) -> None:
         """Instantiate BuildRun object.
 
         Args:
@@ -59,11 +59,11 @@ class BuildRun(Program):
             return (False, 'build script did not produce an executable called "run"')
         return (True, None)
 
-    def get_runcmd(self, cwd=None, memlim=None) -> list[str]:
+    def get_runcmd(self, cwd: str | None = None, memlim: int = 1024) -> list[str]:
         """Run command for the program.
 
         Args:
-            cwd (str): if not None, the run command is provided
+            cwd: if not None, the run command is provided
                 relative to cwd (otherwise absolute paths are given).
         """
         path = self.path if cwd is None else os.path.relpath(self.path, cwd)

--- a/problemtools/run/buildrun.py
+++ b/problemtools/run/buildrun.py
@@ -24,14 +24,14 @@ class BuildRun(Program):
         super().__init__()
 
         if not os.path.isdir(path):
-            raise ProgramError('%s is not a directory' % path)
+            raise ProgramError(f'{path} is not a directory')
 
         if path[-1] == '/':
             path = path[:-1]
         self.name = os.path.basename(path)
         self.path = os.path.join(work_dir, self.name)
         if os.path.exists(self.path):
-            self.path = tempfile.mkdtemp(prefix='%s-' % self.name, dir=work_dir)
+            self.path = tempfile.mkdtemp(prefix=f'{self.name}-', dir=work_dir)
         else:
             os.makedirs(self.path)
 
@@ -39,13 +39,13 @@ class BuildRun(Program):
 
         build = os.path.join(self.path, 'build')
         if not os.path.isfile(build):
-            raise ProgramError('%s does not have a build script' % path)
+            raise ProgramError(f'{path} does not have a build script')
         if not os.access(build, os.X_OK):
-            raise ProgramError('%s/build is not executable' % path)
+            raise ProgramError(f'{path}/build is not executable')
 
     def __str__(self) -> str:
         """String representation"""
-        return '%s (build-run)' % (self.name)
+        return f'{self.name} (build-run)'
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Run the build script."""

--- a/problemtools/run/checktestdata.py
+++ b/problemtools/run/checktestdata.py
@@ -21,7 +21,7 @@ class Checktestdata(Executable):
 
     def __str__(self) -> str:
         """String representation"""
-        return '%s' % (self.args[-1])
+        return self.args[-1]
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Syntax-check the Checktestdata script

--- a/problemtools/run/checktestdata.py
+++ b/problemtools/run/checktestdata.py
@@ -17,11 +17,7 @@ class Checktestdata(Executable):
         Args:
             path: path to .ctd source file
         """
-        super().__init__(sys.executable, args=['-m', 'checktestdata', path])
-
-    def __str__(self) -> str:
-        """String representation"""
-        return self.args[-1]
+        super().__init__(sys.executable, args=['-m', 'checktestdata', path], name=os.path.basename(path))
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Syntax-check the Checktestdata script

--- a/problemtools/run/checktestdata.py
+++ b/problemtools/run/checktestdata.py
@@ -11,7 +11,7 @@ from .executable import Executable
 class Checktestdata(Executable):
     """Wrapper class for running Checktestdata scripts."""
 
-    def __init__(self, path: str):
+    def __init__(self, path: str) -> None:
         """Create a Checktestdata wrapper.
 
         Args:
@@ -34,26 +34,30 @@ class Checktestdata(Executable):
         return ((os.WIFEXITED(status) and os.WEXITSTATUS(status) in [0, 1]), None)
 
     def run(
-        self, infile='/dev/null', outfile='/dev/null', errfile='/dev/null', args=None, timelim=1000, memlim=1024, work_dir=None
-    ):
+        self,
+        infile: str = '/dev/null',
+        outfile: str = '/dev/null',
+        errfile: str = '/dev/null',
+        args: list[str] | None = None,
+        timelim: int = 1000,
+        memlim: int = 1024,
+        work_dir: str | None = None,
+    ) -> tuple[int, float]:
         """Run the Checktestdata script to validate an input file.
 
         Args:
-            infile (str): name of input file to validate
-            outfile (str): file name to save stdout of Checktestdata in
-            errfile (str): file name to save stderr of Checktestdata in
-            args (list of str): additional command-line arguments to
-                pass to Checktestdata
-            timelim (int): time limit for the Checktestdata process in
-                seconds
+            infile: name of input file to validate
+            outfile: file name to save stdout of Checktestdata in
+            errfile: file name to save stderr of Checktestdata in
+            args: additional command-line arguments to pass to Checktestdata
+            timelim: time limit for the Checktestdata process in seconds
 
         Returns:
             tuple (status, runtime):
-                status (int): exit status of the validator.
+                status: exit status of the validator.
                     WEXITSTATUS(status) will be 42 if and only if
                     Checktestdata accepted the input file.
-                runtime (float): runtime of the Checktestdata process
-                    in seconds
+                runtime: runtime of the Checktestdata process in seconds
         """
         (status, runtime) = super().run(
             infile=infile, outfile=outfile, errfile=errfile, args=args, timelim=timelim, memlim=memlim, work_dir=work_dir

--- a/problemtools/run/executable.py
+++ b/problemtools/run/executable.py
@@ -11,7 +11,7 @@ from .program import Program
 class Executable(Program):
     """Class for executable files."""
 
-    def __init__(self, path: str, args: list[str] | None = None) -> None:
+    def __init__(self, path: str, args: list[str] | None = None, name: str | None = None) -> None:
         """Instantiate executable object.
 
         Args:
@@ -19,17 +19,12 @@ class Executable(Program):
                 and must be executable.
             args: list of additional command line arguments that
                 should be passed to the program every time it is executed.
+            name: name to use for the program.  Defaults to the basename of path.
         """
-        super().__init__()
-
         if not os.path.isfile(path) or not os.access(path, os.X_OK):
             raise ProgramError(f'{path} is not an executable program')
-        self.path = path
+        super().__init__(path=path, name=name if name is not None else os.path.basename(path))
         self.args = args if args is not None else []
-
-    def __str__(self) -> str:
-        """String representation"""
-        return self.path
 
     def get_runcmd(self, cwd: str | None = None, memlim: int = 1024) -> list[str]:
         """Command to run the program."""

--- a/problemtools/run/executable.py
+++ b/problemtools/run/executable.py
@@ -23,13 +23,13 @@ class Executable(Program):
         super().__init__()
 
         if not os.path.isfile(path) or not os.access(path, os.X_OK):
-            raise ProgramError('%s is not an executable program' % path)
+            raise ProgramError(f'{path} is not an executable program')
         self.path = path
         self.args = args if args is not None else []
 
     def __str__(self) -> str:
         """String representation"""
-        return '%s' % (self.path)
+        return self.path
 
     def get_runcmd(self, cwd: str | None = None, memlim: int = 1024) -> list[str]:
         """Command to run the program."""

--- a/problemtools/run/executable.py
+++ b/problemtools/run/executable.py
@@ -11,7 +11,7 @@ from .program import Program
 class Executable(Program):
     """Class for executable files."""
 
-    def __init__(self, path: str, args: list[str] | None = None):
+    def __init__(self, path: str, args: list[str] | None = None) -> None:
         """Instantiate executable object.
 
         Args:
@@ -27,14 +27,14 @@ class Executable(Program):
         self.path = path
         self.args = args if args is not None else []
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation"""
         return '%s' % (self.path)
 
-    def get_runcmd(self, cwd=None, memlim=None):
+    def get_runcmd(self, cwd: str | None = None, memlim: int = 1024) -> list[str]:
         """Command to run the program."""
         return [self.path] + self.args
 
-    def should_skip_memory_rlimit(self):
+    def should_skip_memory_rlimit(self) -> bool:
         """Ugly hack (see program.py for details)."""
         return True

--- a/problemtools/run/limit.py
+++ b/problemtools/run/limit.py
@@ -19,22 +19,18 @@ def check_limit_capabilities(diagnostics: Diagnostics) -> None:
     """
     (_, cpu_hard) = resource.getrlimit(resource.RLIMIT_CPU)
     if cpu_hard != resource.RLIM_INFINITY:
-        diagnostics.warning(
-            'Hard CPU rlimit of %d, runs involving higher CPU limits than this may behave incorrectly.' % cpu_hard
-        )
+        diagnostics.warning(f'Hard CPU rlimit of {cpu_hard}, runs involving higher CPU limits than this may behave incorrectly.')
 
     (_, stack_hard) = resource.getrlimit(resource.RLIMIT_STACK)
     if stack_hard != resource.RLIM_INFINITY:
         diagnostics.warning(
-            "Hard stack rlimit of %d so I can't set it to unlimited. I will keep it at %d. If you experience unexpected issues (in particular run-time errors) this may be the cause."
-            % (stack_hard, stack_hard)
+            f"Hard stack rlimit of {stack_hard} so I can't set it to unlimited. I will keep it at {stack_hard}. If you experience unexpected issues (in particular run-time errors) this may be the cause."
         )
 
     (_, mem_hard) = resource.getrlimit(resource.RLIMIT_AS)
     if mem_hard != resource.RLIM_INFINITY:
         diagnostics.warning(
-            'Hard memory rlimit of %.0f MiB, runs involving a higher memory limit may behave incorrectly.  If you experience unexpected issues (in particular run-time errors) this may be the cause.'
-            % (mem_hard / 1024.0 / 1024.0)
+            f'Hard memory rlimit of {mem_hard / 1024.0 / 1024.0:.0f} MiB, runs involving a higher memory limit may behave incorrectly.  If you experience unexpected issues (in particular run-time errors) this may be the cause.'
         )
 
 

--- a/problemtools/run/limit.py
+++ b/problemtools/run/limit.py
@@ -4,37 +4,41 @@ Module for dealing with resource limits for problemtools runs.
 
 import resource
 
+from ..diagnostics import Diagnostics
 
-def check_limit_capabilities(logger):
+
+def check_limit_capabilities(diagnostics: Diagnostics) -> None:
     """Check if the problemtools process is run with appropriate
     capabilities to set rlimits, and if not, issue warnings.
 
     Params:
-        logger: object to issue warnings to (by calling 'warning' method)
+        diagnostics: Diagnostics to issue warnings to
 
     FIXME: if running as root with a hard stack or cpu rlimit set,
     this will still issue warnings.
     """
     (_, cpu_hard) = resource.getrlimit(resource.RLIMIT_CPU)
     if cpu_hard != resource.RLIM_INFINITY:
-        logger.warning('Hard CPU rlimit of %d, runs involving higher CPU limits than this may behave incorrectly.' % cpu_hard)
+        diagnostics.warning(
+            'Hard CPU rlimit of %d, runs involving higher CPU limits than this may behave incorrectly.' % cpu_hard
+        )
 
     (_, stack_hard) = resource.getrlimit(resource.RLIMIT_STACK)
     if stack_hard != resource.RLIM_INFINITY:
-        logger.warning(
+        diagnostics.warning(
             "Hard stack rlimit of %d so I can't set it to unlimited. I will keep it at %d. If you experience unexpected issues (in particular run-time errors) this may be the cause."
             % (stack_hard, stack_hard)
         )
 
     (_, mem_hard) = resource.getrlimit(resource.RLIMIT_AS)
     if mem_hard != resource.RLIM_INFINITY:
-        logger.warning(
+        diagnostics.warning(
             'Hard memory rlimit of %.0f MiB, runs involving a higher memory limit may behave incorrectly.  If you experience unexpected issues (in particular run-time errors) this may be the cause.'
             % (mem_hard / 1024.0 / 1024.0)
         )
 
 
-def try_limit(limit, soft, hard):
+def try_limit(limit: int, soft: int, hard: int) -> None:
     """Attempt to set an rlimit, but caps it at the current hard limit for
     the resource (instead of failing like a call to resource.setrlimit
     would).
@@ -52,12 +56,12 @@ def try_limit(limit, soft, hard):
     resource.setrlimit(limit, (soft, hard))
 
 
-def __limit_less(lim1, lim2):
+def __limit_less(lim1: int, lim2: int) -> bool:
     """Helper function for comparing two rlimit values, handling "unlimited" correctly.
 
     Params:
-        lim1 (integer): first rlimit
-        lim2 (integer): second rlimit
+        lim1: first rlimit
+        lim2: second rlimit
 
     Returns:
         true if lim1 <= lim2

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -52,7 +52,7 @@ class Program(ABC):
         """
         runcmd = self.get_runcmd(memlim=memlim)
         if runcmd == []:
-            raise ProgramError('Could not figure out how to run %s' % self)
+            raise ProgramError(f'Could not figure out how to run {self}')
         if args is None:
             args = []
 

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -16,10 +16,20 @@ log = logging.getLogger(__name__)
 class Program(ABC):
     """Abstract base class for programs."""
 
-    def __init__(self) -> None:
-        self.path: str = ''
+    def __init__(self, path: str, name: str) -> None:
+        """Instantiate program object.
+
+        Args:
+            path: full path to the program (possibly in a temporary directory).
+            name: human-readable name of the program.
+        """
+        self.path = path
+        self.name = name
         self._compile_lock = threading.Lock()
         self._compile_result: tuple[bool, str | None] | None = None
+
+    def __str__(self) -> str:
+        return self.name
 
     @abstractmethod
     def get_runcmd(self, cwd: str | None = None, memlim: int = 1024) -> list[str]:

--- a/problemtools/run/program.py
+++ b/problemtools/run/program.py
@@ -22,35 +22,39 @@ class Program(ABC):
         self._compile_result: tuple[bool, str | None] | None = None
 
     @abstractmethod
-    def get_runcmd(self, cwd=None, memlim=None) -> list[str]:
+    def get_runcmd(self, cwd: str | None = None, memlim: int = 1024) -> list[str]:
         pass
 
     def run(
-        self, infile='/dev/null', outfile='/dev/null', errfile='/dev/null', args=None, timelim=1000, memlim=1024, work_dir=None
-    ):
+        self,
+        infile: str = '/dev/null',
+        outfile: str = '/dev/null',
+        errfile: str = '/dev/null',
+        args: list[str] | None = None,
+        timelim: int = 1000,
+        memlim: int = 1024,
+        work_dir: str | None = None,
+    ) -> tuple[int, float]:
         """Run the program.
 
         Args:
-            infile (str): name of file to pass on stdin
-            outfile (str): name of file to send stdout to
-            errfile (str): name of file to send stderr to
-            args (list of str): additional command-line arguments to
-                pass to the program
-            timelim (int): CPU time limit in seconds
-            memlim (int): memory limit in MiB
+            infile: name of file to pass on stdin
+            outfile: name of file to send stdout to
+            errfile: name of file to send stderr to
+            args: additional command-line arguments to pass to the program
+            timelim: CPU time limit in seconds
+            memlim: memory limit in MiB
 
         Returns:
             pair (status, runtime):
-               status (int): exit status of the process
-               runtime (float): user+sys runtime of the process, in seconds
+               status: exit status of the process
+               runtime: user+sys runtime of the process, in seconds
         """
         runcmd = self.get_runcmd(memlim=memlim)
         if runcmd == []:
             raise ProgramError('Could not figure out how to run %s' % self)
         if args is None:
             args = []
-        if self.should_skip_memory_rlimit():
-            memlim = None
 
         status, runtime = self.__run_wait(runcmd + args, infile, outfile, errfile, timelim, memlim, work_dir)
 
@@ -87,8 +91,16 @@ class Program(ABC):
         """
         return False
 
-    @staticmethod
-    def __run_wait(argv, infile, outfile, errfile, timelim, memlim, working_directory=None):
+    def __run_wait(
+        self,
+        argv: list[str],
+        infile: str,
+        outfile: str,
+        errfile: str,
+        timelim: int,
+        memlim: int,
+        work_dir: str | None,
+    ) -> tuple[int, float]:
         log.debug('run "%s < %s > %s 2> %s"', ' '.join(argv), infile, outfile, errfile)
         pid = os.fork()
         if pid == 0:  # child
@@ -109,17 +121,16 @@ class Program(ABC):
                 if hasattr(signal, 'SIGXFSZ'):
                     signal.signal(signal.SIGXFSZ, signal.SIG_DFL)
 
-                if timelim is not None:
-                    limit.try_limit(resource.RLIMIT_CPU, timelim, timelim + 1)
-                if memlim is not None:
+                limit.try_limit(resource.RLIMIT_CPU, timelim, timelim + 1)
+                if not self.should_skip_memory_rlimit():
                     limit.try_limit(resource.RLIMIT_AS, memlim * (1024**2), resource.RLIM_INFINITY)
                 limit.try_limit(resource.RLIMIT_STACK, resource.RLIM_INFINITY, resource.RLIM_INFINITY)
 
                 Program.__setfd(0, infile, os.O_RDONLY)
                 Program.__setfd(1, outfile, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
                 Program.__setfd(2, errfile, os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
-                if working_directory is not None:
-                    os.chdir(working_directory)
+                if work_dir is not None:
+                    os.chdir(work_dir)
                 os.execvp(argv[0], argv)
             except Exception as exc:
                 print('Oops. Fatal error in child process:')
@@ -132,7 +143,7 @@ class Program(ABC):
         return status, rusage.ru_utime + rusage.ru_stime
 
     @staticmethod
-    def __setfd(fd, filename, flag):
+    def __setfd(fd: int, filename: str, flag: int) -> None:
         tmpfd = os.open(filename, flag)
         os.dup2(tmpfd, fd)
         os.close(tmpfd)

--- a/problemtools/run/rutil.py
+++ b/problemtools/run/rutil.py
@@ -34,7 +34,7 @@ def add_files(src: str, dstdir: str) -> None:
     except OSError as exc:
         # FIXME why is this specific error special-cased
         if exc.errno == errno.ENOENT:
-            raise ProgramError('File not found when copying program:\n %s' % exc.filename)
+            raise ProgramError(f'File not found when copying program:\n {exc.filename}')
         raise
 
 

--- a/problemtools/run/rutil.py
+++ b/problemtools/run/rutil.py
@@ -7,21 +7,18 @@ import shutil
 from .errors import ProgramError
 
 
-def add_files(src, dstdir):
+def add_files(src: str, dstdir: str) -> None:
     """Copy src to dstdir.
 
     Args:
-        src (str): path of file(s) to copy.
+        src: path of file(s) to copy.
             If path is a file, that file will simply be copied to
             dstdir.
             If path is a directory, then every entry (both files and
             subdirectories) in that directory will be copied to
             dstdir.
-        dstdir (str): directory into which to copy src.  Must be an
+        dstdir: directory into which to copy src.  Must be an
             existing directory.
-
-    Returns:
-        None
     """
     try:
         if os.path.isfile(src):
@@ -41,12 +38,12 @@ def add_files(src, dstdir):
         raise
 
 
-def list_files_recursive(root):
+def list_files_recursive(root: str) -> list[str]:
     """List files in a directory with subdirectories.
 
     Returns:
-        list of str, all file names for all files contained in a
-        directory and its subdirectories.
+        all file names for all files contained in a directory and its
+        subdirectories.
     """
     ret = []
     for path, _, files in os.walk(root):

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 class SourceCode(Program):
     """Class representing a program provided by source code."""
 
-    def __init__(self, path: str, language: Language, work_dir: str, includes: LanguageIncludes):
+    def __init__(self, path: str, language: Language, work_dir: str, includes: LanguageIncludes) -> None:
         """Instantiate SourceCode object
 
         Args:
@@ -103,15 +103,14 @@ class SourceCode(Program):
         except subprocess.CalledProcessError as err:
             return (False, err.output.decode('utf8', 'replace'))
 
-    def get_runcmd(self, cwd=None, memlim=1024):
+    def get_runcmd(self, cwd: str | None = None, memlim: int = 1024) -> list[str]:
         """Run command for the program.
 
         Args:
-            cwd (str): if not None, the run command is provided
+            cwd: if not None, the run command is provided
                 relative to cwd (otherwise absolute paths are given).
-            memlim (int): if not None, memory limit in MiB (only
-                relevant for languages where memory limit is passed on
-                command line)
+            memlim: memory limit in MiB (only relevant for
+                languages where memory limit is passed on command line)
         """
         self.compile()
         subs = self.__get_substitution(memlim)

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -39,19 +39,18 @@ class SourceCode(Program):
                 a mainfile, that takes precedence over the one we would
                 otherwise have detected.
         """
-        super().__init__()
-
         if path[-1] == '/':
             path = path[:-1]
-        self.name = os.path.basename(path)
-        self.language = language
+        name = os.path.basename(path)
 
         # Set up work-space
-        self.path = os.path.join(work_dir, self.name)
-        if os.path.exists(self.path):
-            self.path = tempfile.mkdtemp(prefix=f'{self.name}-', dir=work_dir)
+        run_path = os.path.join(work_dir, name)
+        if os.path.exists(run_path):
+            run_path = tempfile.mkdtemp(prefix=f'{name}-', dir=work_dir)
         else:
-            os.makedirs(self.path)
+            os.makedirs(run_path)
+        super().__init__(path=run_path, name=name)
+        self.language = language
 
         # Copy all files
         rutil.add_files(path, self.path)

--- a/problemtools/run/source.py
+++ b/problemtools/run/source.py
@@ -49,7 +49,7 @@ class SourceCode(Program):
         # Set up work-space
         self.path = os.path.join(work_dir, self.name)
         if os.path.exists(self.path):
-            self.path = tempfile.mkdtemp(prefix='%s-' % self.name, dir=work_dir)
+            self.path = tempfile.mkdtemp(prefix=f'{self.name}-', dir=work_dir)
         else:
             os.makedirs(self.path)
 
@@ -64,7 +64,7 @@ class SourceCode(Program):
 
         self.src = sorted(self.language.get_source_files(rutil.list_files_recursive(self.path)))
         if len(self.src) == 0:
-            raise ProgramError('No source files found for language %s in %s' % (self.language.lang_id, self.name))
+            raise ProgramError(f'No source files found for language {self.language.lang_id} in {self.name}')
 
         if includes.mainfile is not None:
             self.mainfile = os.path.join(self.path, includes.mainfile)
@@ -126,7 +126,7 @@ class SourceCode(Program):
 
     def __str__(self) -> str:
         """String representation"""
-        return '%s (%s)' % (self.name, self.language.name)
+        return f'{self.name} ({self.language.name})'
 
     def __get_substitution(self, memlim: int = 1024) -> CommandSubstitution:
         return CommandSubstitution(

--- a/problemtools/run/tools.py
+++ b/problemtools/run/tools.py
@@ -3,15 +3,15 @@ import os
 from .executable import Executable
 
 
-def get_tool_path(name):
+def get_tool_path(name: str) -> str | None:
     """Find the path to one of problemtools' external tools.
 
     Args:
-        name (str): which tool is wanted (one of [default_grader,
+        name: which tool is wanted (one of [default_grader,
             default_validator, interactive, checktestdata, viva.sh])
 
     Returns:
-        str, path to the tool, or None if the tool was not found.
+        path to the tool, or None if the tool was not found.
     """
     return __locate_executable(
         [
@@ -21,11 +21,11 @@ def get_tool_path(name):
     )
 
 
-def get_tool(name):
+def get_tool(name: str) -> Executable | None:
     """Get an Executable instance for one of problemtools' external tools.
 
     Args:
-        name(str): same as for get_tool_path
+        name: same as for get_tool_path
 
     Returns:
         problemtools.run.Executable object for the tool, or None if
@@ -35,15 +35,15 @@ def get_tool(name):
     return Executable(path) if path is not None else None
 
 
-def __locate_executable(candidate_paths):
+def __locate_executable(candidate_paths: list[str]) -> str | None:
     """Find executable among a set of paths.
 
     Args:
-        candidate_paths (list of str): list of locations in which to
-            look for an executable file.
+        candidate_paths: list of locations in which to look for an
+            executable file.
 
     Returns:
-        str, first entry of candidate_paths that is an executable
-            file, or None if no such entry.
+        first entry of candidate_paths that is an executable file, or
+        None if no such entry.
     """
     return next((p for p in candidate_paths if os.path.isfile(p) and os.access(p, os.X_OK)), None)

--- a/problemtools/run/viva.py
+++ b/problemtools/run/viva.py
@@ -22,11 +22,7 @@ class Viva(Executable):
         """
         if Viva._VIVA_PATH is None:
             raise ProgramError(f'Could not locate the VIVA program to run {path}')
-        super().__init__(Viva._VIVA_PATH, args=[path])
-
-    def __str__(self) -> str:
-        """String representation"""
-        return self.args[0]
+        super().__init__(Viva._VIVA_PATH, args=[path], name=os.path.basename(path))
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Syntax-check the VIVA script

--- a/problemtools/run/viva.py
+++ b/problemtools/run/viva.py
@@ -14,7 +14,7 @@ class Viva(Executable):
 
     _VIVA_PATH = get_tool_path('viva.sh')
 
-    def __init__(self, path: str):
+    def __init__(self, path: str) -> None:
         """Create a VIVA wrapper.
 
         Args:
@@ -24,7 +24,7 @@ class Viva(Executable):
             raise ProgramError('Could not locate the VIVA program to run %s' % path)
         super().__init__(Viva._VIVA_PATH, args=[path])
 
-    def __str__(self):
+    def __str__(self) -> str:
         """String representation"""
         return '%s' % (self.args[0])
 
@@ -38,24 +38,30 @@ class Viva(Executable):
         return ((os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0), None)
 
     def run(
-        self, infile='/dev/null', outfile='/dev/null', errfile='/dev/null', args=None, timelim=1000, memlim=1024, work_dir=None
-    ):
+        self,
+        infile: str = '/dev/null',
+        outfile: str = '/dev/null',
+        errfile: str = '/dev/null',
+        args: list[str] | None = None,
+        timelim: int = 1000,
+        memlim: int = 1024,
+        work_dir: str | None = None,
+    ) -> tuple[int, float]:
         """Run the VIVA script to validate an input file.
 
         Args:
-            infile (str): name of input file to validate
-            outfile (str): file name to save stdout of VIVA in
-            errfile (str): file name to save stderr of VIVA in
-            args (list of str): additional command-line arguments to
-                pass to VIVA
-            timelim (int): time limit for the VIVA process in seconds
+            infile: name of input file to validate
+            outfile: file name to save stdout of VIVA in
+            errfile: file name to save stderr of VIVA in
+            args: additional command-line arguments to pass to VIVA
+            timelim: time limit for the VIVA process in seconds
 
         Returns:
             tuple (status, runtime):
-                status (int): exit status of the validator.
+                status: exit status of the validator.
                     WEXITSTATUS(status) will be 42 if and only if VIVA
                     accepted the input file.
-                runtime (float): runtime of the VIVA process in seconds
+                runtime: runtime of the VIVA process in seconds
         """
         if args is None:
             args = []

--- a/problemtools/run/viva.py
+++ b/problemtools/run/viva.py
@@ -21,12 +21,12 @@ class Viva(Executable):
             path: path to .viva source file
         """
         if Viva._VIVA_PATH is None:
-            raise ProgramError('Could not locate the VIVA program to run %s' % path)
+            raise ProgramError(f'Could not locate the VIVA program to run {path}')
         super().__init__(Viva._VIVA_PATH, args=[path])
 
     def __str__(self) -> str:
         """String representation"""
-        return '%s' % (self.args[0])
+        return self.args[0]
 
     def do_compile(self) -> tuple[bool, str | None]:
         """Syntax-check the VIVA script

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from functools import cached_property
 from pathlib import Path
 from re import Match, Pattern
-from typing import Any, ClassVar, Literal, ParamSpec, TypeVar
+from typing import Any, ClassVar, Literal, NoReturn, ParamSpec, TypeVar
 
 import yaml
 from pydantic import ValidationError
@@ -59,7 +59,7 @@ class ProblemAspect(ABC):
     def warnings(self) -> int:
         return self._diag.warnings
 
-    def fatal(self, msg: str, additional_info: str | None = None) -> None:
+    def fatal(self, msg: str, additional_info: str | None = None) -> NoReturn:
         self._check_res = False
         self._diag.fatal(msg, additional_info)
 
@@ -958,6 +958,8 @@ class OutputValidators(ProblemPart):
     @property
     def output_validator(self) -> run.Program:
         if self.uses_default_validator() or not self._validators:
+            if self._default_validator is None:
+                self.fatal('Unable to locate default validator')
             return self._default_validator
         return self._validators[0]
 
@@ -994,9 +996,6 @@ class OutputValidators(ProblemPart):
             self.error('There are validator programs but problem.yaml has validation = "default"')
         elif not self.uses_default_validator() and not self._validators:
             self.fatal('problem.yaml specifies custom validator but no validator programs found')
-
-        if self.uses_default_validator() and self._default_validator is None:
-            self.fatal('Unable to locate default validator')
 
         try:
             success, msg = self.output_validator.compile()
@@ -1492,7 +1491,7 @@ class Problem(ProblemAspect):
             self._check_file_and_directory_names()
             self._check_submission_directory_names()
 
-            run.limit.check_limit_capabilities(self)
+            run.limit.check_limit_capabilities(self._diag)
 
             parts = [
                 part for part in part_mapping if part in context.parts

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -1220,7 +1220,7 @@ class Submissions(ProblemPart):
 
         rows = []
         for sub, results in all_submission_results:
-            row = [sub.name]  # type: ignore
+            row = [sub.name]
             for g in groups:
                 row.append(cell_for_group(results, g))
             if is_scoring:
@@ -1258,7 +1258,7 @@ class Submissions(ProblemPart):
         for verdict in Submissions._VERDICTS:
             acr = verdict[0]
             for sub in self._submissions[acr]:
-                sub_name = sub.name  # type: ignore
+                sub_name = sub.name
                 if context.submission_filter.search(os.path.join(verdict[1], sub_name)):
                     context.submit_background_work(lambda s: s.compile(), sub)
 
@@ -1305,7 +1305,7 @@ class Submissions(ProblemPart):
             runtimes = []
 
             for sub in self._submissions[acr]:
-                sub_name = sub.name  # type: ignore
+                sub_name = sub.name
                 if context.submission_filter.search(os.path.join(verdict[1], sub_name)):
                     self.info(f'Check {acr} submission {sub}')
 


### PR DESCRIPTION
Most of this PR is adding actual type annotations (instead of comments) in the run module, and replacing %-strings with f-strings.

One behavioral change is that build-run programs now print their stdout + stderr (possibly truncated) on compile errors.

