### PR TITLE
Update Arch Linux instructions on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,14 @@ Followed by:
 
     pip3 install --user plastex nh3
 
-### Arch
-Package is available on the AUR [kattis-problemtools-git](https://aur.archlinux.org/packages/kattis-problemtools-git). Use your favorite AUR helper or follow the installation instructions found [here](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
+### Arch Linux
+
+Package is available on the AUR
+[kattis-problemtools](https://aur.archlinux.org/packages/kattis-problemtools) or
+[kattis-problemtools-git](https://aur.archlinux.org/packages/kattis-problemtools-git).
+Use your favorite AUR helper or
+follow the installation instructions found
+[here](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
 
 ### Other platforms
 


### PR DESCRIPTION
### Context

The previous/existing [kattis-problemtools-git](https://aur.archlinux.org/packages/kattis-problemtools-git) package would install whatever version was on `main`.

I have created a new package on AUR that installs the latest release, v1.20260620 as of now: [kattis-problemtools](https://aur.archlinux.org/packages/kattis-problemtools).

### Changes

This PR adds the link to the new package ([kattis-problemtools](https://aur.archlinux.org/packages/kattis-problemtools)) on the README.  It also changes the colloquial "Arch" to the more standard "Arch Linux".  See diff for details.

### Further info

If any of you would like to be co-maintainers or main-maintainers on the new AUR package let me know, I'll gladly give you write permissions there.  :-)