### PR TITLE
Remove outdated dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ for any languages used in problem packages.
 
 The dependencies needed to *build/install* problemtools can be installed with:
 
-    sudo apt install python3-venv automake g++ make libboost-regex-dev libgmp-dev python3 git
+    sudo apt install python3-venv automake g++ make python3 git
 
 And the dependencies needed to *run* problemtools can be installed with:
 
@@ -249,7 +249,7 @@ To render problem statements to pdf with non-latin characters, also add the foll
 
 On Fedora, these dependencies can be installed with:
 
-    sudo dnf install boost-regex gcc gmp-devel gmp-c++ pandoc python3 python3-pyyaml texlive-latex texlive-collection-fontsrecommended texlive-fancyhdr texlive-subfigure texlive-wrapfig texlive-import texlive-ulem texlive-xifthen texlive-overpic texlive-pbox tidy ghostscript
+    sudo dnf install gcc pandoc python3 python3-pyyaml texlive-latex texlive-collection-fontsrecommended texlive-fancyhdr texlive-subfigure texlive-wrapfig texlive-import texlive-ulem texlive-xifthen texlive-overpic texlive-pbox tidy ghostscript
 
 Followed by:
 

--- a/admin/build_pypi_packages.sh
+++ b/admin/build_pypi_packages.sh
@@ -42,7 +42,6 @@ fi
 echo "Building sdist and manylinux wheel"
 sudo rm -rf ./pypi_dist
 docker run --rm -v $(pwd)/..:/problemtools -v $(pwd)/pypi_dist:/dist quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "
-    yum -y install boost-devel gmp-devel ;
     mkdir /build ;
     cd /build ;
     git config --global --add safe.directory /problemtools/.git ;

--- a/admin/docker/Dockerfile.build
+++ b/admin/docker/Dockerfile.build
@@ -20,5 +20,4 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         dpkg-dev \
         g++ \
         git \
-        make \
-        libboost-regex-dev
+        make

--- a/admin/docker/Dockerfile.githubci
+++ b/admin/docker/Dockerfile.githubci
@@ -19,5 +19,4 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         dh-virtualenv \
         dpkg-dev \
         git \
-        make \
-        libboost-regex-dev
+        make

--- a/admin/docker/Dockerfile.runreqs
+++ b/admin/docker/Dockerfile.runreqs
@@ -9,8 +9,6 @@ LABEL maintainer="contact@kattis.com"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Packages required to build and run problemtools
-# For libgmp, we technically just need libgmpxx4ldbl here, but for readability
-# (and we need libgmp-dev in other images), we take libgmp-dev here
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     rm -f /etc/apt/apt.conf.d/docker-clean && \
@@ -19,7 +17,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         fonts-cmu \
         fonts-noto-color-emoji \
         ghostscript \
-        libgmp-dev \
         pandoc \
         python3 \
         python3-venv \

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kattis-problemtools
 Section: devel
 Priority: optional
 Maintainer: Per Austrin <austrin@kattis.com>
-Build-Depends: debhelper-compat (= 13), g++ (>= 4.8), dh-virtualenv, python3, libboost-regex-dev, libgmp-dev, automake, autoconf, git, python3-venv, dpkg-dev
+Build-Depends: debhelper-compat (= 13), g++ (>= 4.8), dh-virtualenv, python3, automake, autoconf, git, python3-venv, dpkg-dev
 Standards-Version: 3.9.4
 Homepage: https://github.com/Kattis/problemtools
 


### PR DESCRIPTION
Follow up of #436. I think boost and gmp are no longer actually used by problemtools.