### PR TITLE
Set mypy to require full type annotation for all methods

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,5 +2,6 @@
 ignore_missing_imports = False
 follow_untyped_imports = True
 install_types = True
-check_untyped_defs = True
+disallow_untyped_defs = True
+disallow_untyped_decorators = True
 ignore_errors = False

--- a/problemtools/ProblemPlasTeX/ProblemsetMacros.py
+++ b/problemtools/ProblemPlasTeX/ProblemsetMacros.py
@@ -2,6 +2,7 @@
 import os
 import os.path
 import sys
+from typing import Any
 
 from plasTeX.Base import Command, DimenCommand
 from plasTeX.DOM import Node
@@ -19,7 +20,7 @@ class textwidth(DimenCommand):
 
 # Convert an expression of the form "X\textwidth" to 100*x%
 # (Used in ugly hack to handle illustrations)
-def clean_width(width):
+def clean_width(width: Any) -> Any:
     if not isinstance(width, Node):
         return width
     nodes = width.childNodes
@@ -32,7 +33,7 @@ def clean_width(width):
 class problemheader(Command):
     args = 'title id:str'
 
-    def invoke(self, tex):
+    def invoke(self, tex: Any) -> None:
         super().invoke(tex)
         timelimfile = os.path.join(os.path.dirname(tex.filename), '..', '.timelimit')
         if os.path.isfile(timelimfile):
@@ -44,11 +45,11 @@ class problemheader(Command):
 class sampletable(Command):
     args = 'header1 file1:str header2 file2:str'
 
-    def read_sample_file(self, filename):
+    def read_sample_file(self, filename: str) -> str:
         with open(filename, 'r', encoding='utf-8') as f:
             return f.read()
 
-    def invoke(self, tex):
+    def invoke(self, tex: Any) -> None:
         super().invoke(tex)
         dir = os.path.dirname(tex.filename)
         file1 = os.path.join(dir, self.attributes['file1'])
@@ -67,10 +68,10 @@ class sampletable(Command):
 class sampletableinteractive(Command):
     args = 'header read write file:str'
 
-    def read_sample_interaction(self, filename):
+    def read_sample_interaction(self, filename: str) -> list[dict[str, str]]:
         with open(filename, 'r', encoding='utf-8') as f:
             data = f.read()
-        messages = []
+        messages: list[dict[str, str]] = []
         cur_msg: list[str] = []
         cur_mode = None
         for line in data.split('\n'):
@@ -93,7 +94,7 @@ class sampletableinteractive(Command):
             messages.append({'mode': cur_mode, 'data': '\n'.join(cur_msg)})
         return messages
 
-    def invoke(self, tex):
+    def invoke(self, tex: Any) -> None:
         super().invoke(tex)
         dir = os.path.dirname(tex.filename)
         file = os.path.join(dir, self.attributes['file'])
@@ -109,7 +110,7 @@ class sampletableinteractive(Command):
 # re-implementation of \includegraphics.  (Based on plasTeX's
 # \includegraphics implementation)
 class _graphics_command(Command):
-    def invoke(self, tex):
+    def invoke(self, tex: Any) -> Any:
         res = super().invoke(tex)
 
         # Overcome plasTeX bug by looking for love in the right place
@@ -149,7 +150,7 @@ class _graphics_command(Command):
 class illustration(_graphics_command):
     args = 'width:double file:str description'
 
-    def invoke(self, tex):
+    def invoke(self, tex: Any) -> Any:
         res = _graphics_command.invoke(self, tex)
         self.style['width'] = '%.2f%%' % (100 * self.attributes['width'])
         return res
@@ -170,7 +171,7 @@ class ExecuteOptions(Command):
     pass
 
 
-def init(tex):
+def init(tex: Any) -> None:
     # Dirty hack #25783 to get plasTeX to work properly:
     # any subprocess of the tex instance won't remember things like,
     # say, the name of the .tex file being processed, which is needed

--- a/problemtools/ProblemPlasTeX/__init__.py
+++ b/problemtools/ProblemPlasTeX/__init__.py
@@ -2,7 +2,7 @@ import os
 import re
 import shutil
 import subprocess
-from typing import Final
+from typing import Any, Final
 
 from plasTeX.Filenames import Filenames
 from plasTeX.Imagers import Image
@@ -25,12 +25,12 @@ class ImageConverter:
         '.pdf': ('.png', ['gs', '-dUseCropBox', '-sDEVICE=pngalpha', '-r300', '-o'])
     }
 
-    def __init__(self, document):
+    def __init__(self, document: Any) -> None:
         self.config = document.config
         self.ownerDocument = document
 
         # Cache of already seen images
-        self.staticimages = {}
+        self.staticimages: dict[str, Image] = {}
 
         # Filename generator
         self.newFilename = Filenames(
@@ -41,10 +41,10 @@ class ImageConverter:
             invalid={},
         )
 
-    def close(self):
+    def close(self) -> None:
         return
 
-    def getImage(self, node):
+    def getImage(self, node: Any) -> Image | None:
         name = getattr(node, 'imageoverride', None)
         if name is None:
             log.error(f'Image handler called for non-image node "{node.source}"')
@@ -93,7 +93,7 @@ class ProblemRenderer(Renderer):
     imageTypes: list[str] = ['.png', '.jpg', '.jpeg', '.gif']  # noqa: RUF012
     vectorImageTypes: list[str] = ['.svg']  # noqa: RUF012
 
-    def render(self, document, postProcess=None):
+    def render(self, document: Any, postProcess: Any = None) -> None:
         templatepaths = [
             os.path.join(os.path.dirname(__file__), '../templates/html'),
             os.path.join(os.path.dirname(__file__), '../../templates/html'),
@@ -121,7 +121,7 @@ class ProblemRenderer(Renderer):
 
         Renderer.render(self, document)
 
-    def processFileContent(self, document, s):
+    def processFileContent(self, document: Any, s: str) -> str:
         s = Renderer.processFileContent(self, document, s)
 
         # Force XHTML syntax on empty tags

--- a/problemtools/ProblemPlasTeX/graphicx.py
+++ b/problemtools/ProblemPlasTeX/graphicx.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from plasTeX.Packages import graphics
 
 from problemtools.ProblemPlasTeX.ProblemsetMacros import _graphics_command, clean_width
@@ -11,7 +13,7 @@ class includegraphics(_graphics_command):
     packageName = 'graphicx'
     captionable = True
 
-    def invoke(self, tex):
+    def invoke(self, tex: Any) -> Any:
         res = _graphics_command.invoke(self, tex)
         options = self.attributes['options']
         if options is not None:

--- a/problemtools/ProblemPlasTeX/import.py
+++ b/problemtools/ProblemPlasTeX/import.py
@@ -1,5 +1,6 @@
 # noqa: N999 -- module name matches the plasTeX \import macro it implements, not PEP 8
 import os
+from typing import Any
 
 from plasTeX.Base import Command
 from plasTeX.Logging import getLogger
@@ -15,7 +16,7 @@ class import_sty(Command):
     macroName = 'import'
     args = 'dir:str file:str'
 
-    def invoke(self, tex):
+    def invoke(self, tex: Any) -> Any:
         a = self.parse(tex)
         path = os.path.join(a['dir'], a['file'])
         fullpath = tex.kpsewhich(path)

--- a/problemtools/ProblemPlasTeX/listingsutf8.py
+++ b/problemtools/ProblemPlasTeX/listingsutf8.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from plasTeX.Base import Command
 from plasTeX.Logging import getLogger
@@ -12,10 +13,10 @@ log = getLogger()
 class lstinputlisting(Command):
     args = '* [ options:dict ] file:str'
 
-    def read_file(self, filename) -> str:
+    def read_file(self, filename: str) -> str:
         return open(filename, 'r', encoding='utf-8').read()
 
-    def invoke(self, tex) -> None:
+    def invoke(self, tex: Any) -> None:
         super().invoke(tex)
         assert self.ownerDocument is not None  # Keep mypy happy
         basetex = self.ownerDocument.userdata['base_tex_instance']

--- a/problemtools/formatversion.py
+++ b/problemtools/formatversion.py
@@ -1,5 +1,6 @@
 from enum import StrEnum
 from pathlib import Path
+from typing import Self
 
 import yaml
 
@@ -45,7 +46,7 @@ class FormatVersion(StrEnum):
     # Support 2023-07 and 2023-07-draft strings.
     # This method should be replaced with an alias once we require python 3.13
     @classmethod
-    def _missing_(cls, value):
+    def _missing_(cls, value: object) -> Self | None:
         if value == '2023-07':
             return cls.V_2023_07
         return None

--- a/problemtools/md2html.py
+++ b/problemtools/md2html.py
@@ -78,7 +78,7 @@ def convert(problem_root: Path, options: argparse.Namespace, statement_file: Pat
 
 def sanitize_html(statement_dir: Path, statement_html: str, imgbasedir: str) -> str:
     # Allow footnote ids (the anchor points you jump to)
-    def is_fn_id(s):
+    def is_fn_id(s: str) -> bool:
         pattern_id_top = r'^fn\d+$'
         pattern_id_bottom = r'^fnref\d+$'
         return bool(re.fullmatch(pattern_id_top, s)) or bool(re.fullmatch(pattern_id_bottom, s))
@@ -88,7 +88,7 @@ def sanitize_html(statement_dir: Path, statement_html: str, imgbasedir: str) -> 
     # Annoying: nh3 will ignore exceptions in attribute_filter
     image_fail_reason: list[Exception] = []
 
-    def attribute_filter(tag, attribute, value):
+    def attribute_filter(tag: str, attribute: str, value: str) -> str | None:
         if attribute == 'class' and value in allowed_classes:
             return value
         # Never versions of Pandoc will give class="footnotes footnotes-end-of-document"

--- a/problemtools/metadata.py
+++ b/problemtools/metadata.py
@@ -2,10 +2,11 @@ import builtins
 import copy
 import datetime
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
-from typing import Any, Literal, Self
+from typing import Any, Literal, Self, TypeVar
 from uuid import UUID
 
 import yaml
@@ -13,6 +14,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from . import config, statement_util
 from .formatversion import FormatVersion
+
+T = TypeVar('T')
 
 
 class ProblemType(StrEnum):
@@ -304,7 +307,7 @@ class Metadata(BaseModel):
         # Convenience function to deal with the fact that lists of persons/sources are
         # either a string, or a list of strings or dicts (if dicts, pydantic
         # already parsed those for us).
-        def parse_list(callback, lst: str | list) -> list:
+        def parse_list(callback: Callable[[str | T], T], lst: str | list[str | T]) -> list[T]:
             if isinstance(lst, str):
                 return [callback(lst)]
             return list(map(callback, lst))

--- a/problemtools/problem2pdf.py
+++ b/problemtools/problem2pdf.py
@@ -45,7 +45,7 @@ def md2pdf(options: argparse.Namespace, statement_file: Path) -> bool:
         print(f'Error compiling Markdown to pdf: {e.stderr}')
         return False
 
-    def format_latex_tables(latex_doc):
+    def format_latex_tables(latex_doc: str) -> str:
         # Match table environments produced by pandoc
         pattern = r"""
             (\\begin\{longtable\}\[\]\{@\{\})
@@ -54,7 +54,7 @@ def md2pdf(options: argparse.Namespace, statement_file: Path) -> bool:
             (@\{\}\})
         """
 
-        def replacer(match):
+        def replacer(match: re.Match[str]) -> str:
             prefix = match.group(1)[:-3]
             first_col = match.group(2)
             other_cols = match.group(3)

--- a/problemtools/statement_util.py
+++ b/problemtools/statement_util.py
@@ -6,7 +6,9 @@ import os
 import re
 import subprocess
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 from . import metadata
@@ -85,7 +87,7 @@ def get_yaml_problem_name(problem_root: Path, language: str) -> str:
     return names[language]
 
 
-def json_dfs(data, callback) -> None:
+def json_dfs(data: Any, callback: Callable[[str], None]) -> None:
     """Traverse all items in a JSON tree, find all images, and call callback for each one"""
     if isinstance(data, dict):
         for key, value in data.items():
@@ -100,7 +102,7 @@ def json_dfs(data, callback) -> None:
             json_dfs(item, callback)
 
 
-def foreach_image(statement_path: Path, callback):
+def foreach_image(statement_path: Path, callback: Callable[[str], None]) -> None:
     """Find all images in the statement and call callback for each one"""
     command = ['pandoc', str(statement_path), '-t', 'json']
     # Must create a working directory for pytest to work

--- a/problemtools/template.py
+++ b/problemtools/template.py
@@ -2,6 +2,8 @@ import os.path
 import shutil
 import tempfile
 from pathlib import Path
+from types import TracebackType
+from typing import Self
 
 
 class TemplateError(Exception):
@@ -35,7 +37,7 @@ class Template:
     TEMPLATE_FILENAME = 'template.tex'
     CLS_FILENAME = 'problemset.cls'
 
-    def __init__(self, problem_root: Path, texfile: Path, language: str, ignore_parent_cls=False):
+    def __init__(self, problem_root: Path, texfile: Path, language: str, ignore_parent_cls: bool = False):
         assert texfile.suffix == '.tex', f'Template asked to render {texfile}, which does not end in .tex'
         assert texfile.is_relative_to(problem_root), f'Template called with tex {texfile} outside of problem {problem_root}'
 
@@ -76,7 +78,7 @@ class Template:
         else:
             self.clsfile = templatepath / self.CLS_FILENAME
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         self._tempdir = tempfile.TemporaryDirectory(prefix='problemtools-')
         temp_dir_path = Path(self._tempdir.name)
 
@@ -104,7 +106,12 @@ class Template:
                         del data['sample']
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: TracebackType | None,
+    ) -> None:
         if self._tempdir:
             self._tempdir.cleanup()
 

--- a/problemtools/verifyproblem.py
+++ b/problemtools/verifyproblem.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from functools import cached_property
 from pathlib import Path
 from re import Match, Pattern
+from types import TracebackType
 from typing import Any, ClassVar, Final, Literal, NoReturn, Self
 
 import yaml
@@ -78,7 +79,7 @@ class ProblemAspect(ABC):
     def debug(self, msg: str) -> None:
         self._diag.debug(msg)
 
-    def msg(self, msg):
+    def msg(self, msg: str) -> None:
         print(msg)
 
     def warn_directory(self, name: str, prop: str) -> None:
@@ -485,7 +486,7 @@ class ProblemStatement(ProblemPart):
     statements: dict[str, list[Path]]  # Maps language code -> statement(s)
     PART_NAME = 'statement'
 
-    def setup(self):
+    def setup(self) -> None:
         self.debug('  Loading problem statement')
         self.statements = statement_util.find_statements(Path(self.problem.probdir), self.problem.format)
 
@@ -573,7 +574,7 @@ class ProblemStatement(ProblemPart):
 class ProblemConfig(ProblemPart):
     PART_NAME = 'config'
 
-    def setup(self):
+    def setup(self) -> None:
         self.debug('  Loading problem config')
         try:
             self._metadata, self._origdata = metadata.load_metadata(Path(self.problem.probdir))
@@ -690,7 +691,7 @@ class Attachments(ProblemPart):
 
     PART_NAME = 'attachments'
 
-    def setup(self):
+    def setup(self) -> None:
         attachments_dir = Path(self.problem.probdir) / 'attachments'
         self.attachments = [p for p in attachments_dir.iterdir()] if attachments_dir.is_dir() else []
         self.debug(f'Adding attachments {self.attachments!s}')
@@ -706,7 +707,7 @@ class Attachments(ProblemPart):
 
         return self._check_res
 
-    def get_attachment_paths(self):
+    def get_attachment_paths(self) -> list[Path]:
         return self.attachments
 
     def __str__(self) -> str:
@@ -751,9 +752,9 @@ _JUNK_CASES_CRASH = [
 
 def _build_junk_modifier(
     desc: str, pattern: str, repl: str | Callable[[Match[str]], str]
-) -> tuple[str, Callable, Callable[[str], str]]:
+) -> tuple[str, Callable[[str], bool], Callable[[str], str]]:
     p = re.compile(pattern)
-    return (desc, p.search, lambda text: p.sub(repl, text))
+    return (desc, lambda text: p.search(text) is not None, lambda text: p.sub(repl, text))
 
 
 _JUNK_MODIFICATIONS = [
@@ -773,7 +774,7 @@ _JUNK_MODIFICATIONS = [
 class InputValidators(ProblemPart):
     PART_NAME = 'input_validator'
 
-    def setup(self):
+    def setup(self) -> None:
         input_validators_path = os.path.join(self.problem.probdir, 'input_format_validators')
         if os.path.isdir(input_validators_path):
             self._uses_old_path = True
@@ -788,7 +789,6 @@ class InputValidators(ProblemPart):
             allow_validation_script=True,
             work_dir=self.problem.tmpdir,
         )
-        return {}
 
     def __str__(self) -> str:
         return 'input format validators'
@@ -841,7 +841,7 @@ class InputValidators(ProblemPart):
                     else:
                         self.warning(f'No validator rejects {desc} with flags "{" ".join(flags)}"')
 
-            def modified_input_validates(applicable, modifier):
+            def modified_input_validates(applicable: Callable[[str], bool], modifier: Callable[[str], str]) -> bool:
                 for testcase in self.problem.testdata.get_all_testcases():
                     try:
                         with open(testcase.infile) as infile:
@@ -903,7 +903,7 @@ class Graders(ProblemPart):
 
     PART_NAME = 'grader'
 
-    def setup(self):
+    def setup(self) -> None:
         graders: list = run.find_programs(
             os.path.join(self.problem.probdir, 'graders'),
             language_config=self.problem.language_config,
@@ -912,7 +912,6 @@ class Graders(ProblemPart):
         if len(graders) > 1:
             self.fatal('There is more than one custom grader')
         self._grader = graders[0] if graders else None
-        return {}
 
     def __str__(self) -> str:
         return 'graders'
@@ -937,7 +936,7 @@ class OutputValidators(ProblemPart):
 
     PART_NAME = 'output_validator'
 
-    def setup(self):
+    def setup(self) -> None:
         self._validators = run.find_programs(
             os.path.join(self.problem.probdir, self.problem.format.output_validator_directory),
             language_config=self.problem.language_config,
@@ -1045,7 +1044,7 @@ class Includes(ProblemPart):
 
     PART_NAME = 'includes'
 
-    def setup(self):
+    def setup(self) -> None:
         self.includes = model.load_includes(Path(self.problem.probdir), self.problem.language_config)
 
     def check(self, context: Context) -> bool:
@@ -1076,7 +1075,7 @@ class Submissions(ProblemPart):
 
     PART_NAME = 'submission'
 
-    def setup(self):
+    def setup(self) -> None:
         self._submissions = {}
         srcdir = os.path.join(self.problem.probdir, 'submissions')
         for verdict in Submissions._VERDICTS:
@@ -1087,13 +1086,12 @@ class Submissions(ProblemPart):
                 work_dir=self.problem.tmpdir,
                 includes=self.problem.includes.includes,
             )
-        return {}
 
     def __str__(self) -> str:
         return 'submissions'
 
     def check_submission(
-        self, sub, context: Context, expected_verdict: Verdict, timelim: float, timelim_high: float
+        self, sub: run.Program, context: Context, expected_verdict: Verdict, timelim: float, timelim_high: float
     ) -> list[SubmissionResult]:
         desc = f'{expected_verdict} submission {sub}'
         partial = expected_verdict == 'PAC'
@@ -1442,7 +1440,12 @@ class Problem(ProblemAspect):
         self.tmpdir = tempfile.mkdtemp(prefix=f'verify-{self.shortname}-')
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: TracebackType | None,
+    ) -> None:
         shutil.rmtree(self.tmpdir)
 
     def __str__(self) -> str:
@@ -1513,13 +1516,13 @@ class Problem(ProblemAspect):
             context.wait_for_background_work()
         return self.errors, self.warnings
 
-    def _check_submission_directory_names(self):
+    def _check_submission_directory_names(self) -> None:
         """Heuristically check if submissions contain any directories that will be ignored because of typos or format mismatches"""
         submission_directories = [p.name for p in (Path(self.probdir) / 'submissions').glob('*') if p.is_dir()]
         if len(submission_directories) == 0:
             return
 
-        def most_similar(present_dir: str, format_version: FormatVersion):
+        def most_similar(present_dir: str, format_version: FormatVersion) -> tuple[str, float]:
             similarities = [
                 (spec_dir, difflib.SequenceMatcher(None, present_dir, spec_dir).ratio())
                 for spec_dir in format_version.submission_directories
@@ -1544,7 +1547,7 @@ class Problem(ProblemAspect):
                         )
                         break
 
-    def _check_symlinks(self):
+    def _check_symlinks(self) -> None:
         """Check that all symlinks point to something existing within the problem package"""
         probdir = os.path.realpath(self.probdir)
         for root, dirs, files in os.walk(probdir):
@@ -1565,7 +1568,7 @@ class Problem(ProblemAspect):
                             f'Symlink {relfile} links to {reltarget} which is an absolute path. Symlinks must be relative.'
                         )
 
-    def _check_file_and_directory_names(self):
+    def _check_file_and_directory_names(self) -> None:
         regex = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,254}$')
 
         def _special_case_allowed_files(file: str, reldir: str) -> bool:


### PR DESCRIPTION
Sets `disallow_untyped_defs = True`, and adds missing type annotations. This prevents us from forgetting to add type annotations to new functions. Also sets `disallow_untyped_decorators = True`, not that I expect that we'll add a ton of decorators. The setting `check_untyped_defs` was dropped, as we now require all functions to be typed.

For code interacting with PlasTeX, we unfortunately end up with a ton of `Any`, as I don't think we have good documentation on what types we'll be called with.

One actual change in the code - in `_build_junk_modifier` I made the return value `bool` via a lambda to get a cleaner type annotation. Aside from that, PR is only type annotations.